### PR TITLE
Fix redundant volume in Dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.project
 /.settings/
 /.idea
+*.iml

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 /.project
 /.settings/
 /.idea
-*.iml

--- a/dsf-fhir/dsf-fhir-server-jetty/docker/Dockerfile
+++ b/dsf-fhir/dsf-fhir-server-jetty/docker/Dockerfile
@@ -2,7 +2,6 @@ FROM openjdk:11-slim
 MAINTAINER Hauke Hund <hauke.hund@hs-heilbronn.de>
 
 EXPOSE 8080
-VOLUME /opt/fhir/conf
 #/opt/fhir/log
 
 RUN adduser --system --no-create-home --group java


### PR DESCRIPTION
Fixed redundant docker volume in Dockerfile of the fhir server, because it already is included in the docker-compose of the application.