### PR TITLE
fixed intendation

### DIFF
--- a/dsf-docker-test-setup/bpe/docker-compose.prod.yml
+++ b/dsf-docker-test-setup/bpe/docker-compose.prod.yml
@@ -3,6 +3,6 @@ services:
   db:
     volumes:
       - ./db/postgres-data:/var/lib/postgresql/data
-    app:
-      extra_hosts:
-        - "<hostname:ip-address>"
+  app:
+    extra_hosts:
+      - "<hostname:ip-address>"


### PR DESCRIPTION
Fixes an issue where docker-compose complains about the invalid syntax:
`ERROR: The Compose file './docker-compose.prod.yml' is invalid because:
Unsupported config option for services.db: 'app'
`
