### PR TITLE
Issues/84 minimize docker layers

### DIFF
--- a/dsf-bpe/dsf-bpe-server-jetty/docker/.dockerignore
+++ b/dsf-bpe/dsf-bpe-server-jetty/docker/.dockerignore
@@ -1,4 +1,5 @@
 .dockerignore
+.gitignore
 Dockerfile
 conf/README.md
 last_event/README.md

--- a/dsf-bpe/dsf-bpe-server-jetty/docker/Dockerfile
+++ b/dsf-bpe/dsf-bpe-server-jetty/docker/Dockerfile
@@ -1,12 +1,21 @@
+FROM debian:buster-slim AS builder
+RUN adduser --system --no-create-home --group --uid 2202 java
+WORKDIR /opt/bpe
+COPY --chown=root:java ./ ./
+RUN chown root:java ./ && \
+    chmod 750 ./ ./lib ./plugin ./dsf_bpe_start.sh && \
+	chmod 640 ./dsf_bpe.jar ./lib/*.jar && \
+	chmod 1775 ./log ./last_event
+
+
 FROM openjdk:11-slim
-MAINTAINER Hauke Hund <hauke.hund@hs-heilbronn.de>
+LABEL maintainer="hauke.hund@hs-heilbronn.de"
 
 EXPOSE 8080
 
 RUN adduser --system --no-create-home --group --uid 2202 java
 WORKDIR /opt/bpe
-COPY --chown=root:java ./ ./
-RUN chown root:java ./ && chmod 750 ./ ./lib ./plugin ./dsf_bpe_start.sh && chmod 640 ./dsf_bpe.jar ./lib/*.jar && chmod 1775 ./log ./last_event
+COPY --from=builder /opt/bpe ./
 
 USER java
 ENTRYPOINT ["./dsf_bpe_start.sh"]

--- a/dsf-docker-test-setup-3medic-ttp/docker-build-tag-push.bat
+++ b/dsf-docker-test-setup-3medic-ttp/docker-build-tag-push.bat
@@ -4,21 +4,21 @@ REM For installing / starting local registry at registry:5000 see test_setup.txt
 REM See https://docs.docker.com/registry/insecure/ for infos on pushing to / pulling from a local insecure registry
 
 echo highmed/bpe ...
-docker build -t highmed/bpe ..\dsf-bpe\dsf-bpe-server-jetty\docker
+docker build --pull -t highmed/bpe ..\dsf-bpe\dsf-bpe-server-jetty\docker
 docker tag highmed/bpe:latest registry:5000/highmed/bpe:latest
 docker push registry:5000/highmed/bpe
 
 echo highmed/bpe_proxy ...
-docker build -t highmed/bpe_proxy ..\dsf-docker\bpe_proxy
+docker build --pull -t highmed/bpe_proxy ..\dsf-docker\bpe_proxy
 docker tag highmed/bpe_proxy:latest registry:5000/highmed/bpe_proxy:latest
 docker push registry:5000/highmed/bpe_proxy
 
 echo highmed/fhir ...
-docker build -t highmed/fhir ..\dsf-fhir\dsf-fhir-server-jetty\docker
+docker build --pull -t highmed/fhir ..\dsf-fhir\dsf-fhir-server-jetty\docker
 docker tag highmed/fhir:latest registry:5000/highmed/fhir:latest
 docker push registry:5000/highmed/fhir
 
 echo highmed/fhir_proxy ...
-docker build -t highmed/fhir_proxy ..\dsf-docker\fhir_proxy
+docker build --pull -t highmed/fhir_proxy ..\dsf-docker\fhir_proxy
 docker tag highmed/fhir_proxy:latest registry:5000/highmed/fhir_proxy:latest
 docker push registry:5000/highmed/fhir_proxy

--- a/dsf-docker-test-setup-3medic-ttp/docker-build-tag-push.sh
+++ b/dsf-docker-test-setup-3medic-ttp/docker-build-tag-push.sh
@@ -4,21 +4,21 @@
 # See https://docs.docker.com/registry/insecure/ for infos on pushing to / pulling from a local insecure registry
 
 echo highmed/bpe ...
-docker build -t highmed/bpe ../dsf-bpe/dsf-bpe-server-jetty/docker
+docker build --pull -t highmed/bpe ../dsf-bpe/dsf-bpe-server-jetty/docker
 docker tag highmed/bpe:latest registry:5000/highmed/bpe:latest
 docker push registry:5000/highmed/bpe
 
 echo highmed/bpe_proxy ...
-docker build -t highmed/bpe_proxy ../dsf-docker/bpe_proxy
+docker build --pull -t highmed/bpe_proxy ../dsf-docker/bpe_proxy
 docker tag highmed/bpe_proxy:latest registry:5000/highmed/bpe_proxy:latest
 docker push registry:5000/highmed/bpe_proxy
 
 echo highmed/fhir ...
-docker build -t highmed/fhir ../dsf-fhir/dsf-fhir-server-jetty/docker
+docker build --pull -t highmed/fhir ../dsf-fhir/dsf-fhir-server-jetty/docker
 docker tag highmed/fhir:latest registry:5000/highmed/fhir:latest
 docker push registry:5000/highmed/fhir
 
 echo highmed/fhir_proxy ...
-docker build -t highmed/fhir_proxy ../dsf-docker/fhir_proxy
+docker build --pull -t highmed/fhir_proxy ../dsf-docker/fhir_proxy
 docker tag highmed/fhir_proxy:latest registry:5000/highmed/fhir_proxy:latest
 docker push registry:5000/highmed/fhir_proxy

--- a/dsf-docker-test-setup/docker-build.bat
+++ b/dsf-docker-test-setup/docker-build.bat
@@ -1,13 +1,13 @@
 @echo off
 
 echo highmed/bpe ...
-docker build -t highmed/bpe ..\dsf-bpe\dsf-bpe-server-jetty\docker
+docker build --pull -t highmed/bpe ..\dsf-bpe\dsf-bpe-server-jetty\docker
 
 echo highmed/bpe_proxy ...
-docker build -t highmed/bpe_proxy ..\dsf-docker\bpe_proxy
+docker build --pull -t highmed/bpe_proxy ..\dsf-docker\bpe_proxy
 
 echo highmed/fhir ...
-docker build -t highmed/fhir ..\dsf-fhir\dsf-fhir-server-jetty\docker
+docker build --pull -t highmed/fhir ..\dsf-fhir\dsf-fhir-server-jetty\docker
 
 echo highmed/fhir_proxy ...
-docker build -t highmed/fhir_proxy ..\dsf-docker\fhir_proxy
+docker build --pull -t highmed/fhir_proxy ..\dsf-docker\fhir_proxy

--- a/dsf-docker-test-setup/docker-build.sh
+++ b/dsf-docker-test-setup/docker-build.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 echo highmed/bpe ...
-docker build -t highmed/bpe ../dsf-bpe/dsf-bpe-server-jetty/docker
+docker build --pull -t highmed/bpe ../dsf-bpe/dsf-bpe-server-jetty/docker
 
 echo highmed/bpe_proxy ...
-docker build -t highmed/bpe_proxy ../dsf-docker/bpe_proxy
+docker build --pull -t highmed/bpe_proxy ../dsf-docker/bpe_proxy
 
 echo highmed/fhir ...
-docker build -t highmed/fhir ../dsf-fhir/dsf-fhir-server-jetty/docker
+docker build --pull -t highmed/fhir ../dsf-fhir/dsf-fhir-server-jetty/docker
 
 echo highmed/fhir_proxy ...
-docker build -t highmed/fhir_proxy ../dsf-docker/fhir_proxy
+docker build --pull -t highmed/fhir_proxy ../dsf-docker/fhir_proxy

--- a/dsf-fhir/dsf-fhir-server-jetty/docker/.dockerignore
+++ b/dsf-fhir/dsf-fhir-server-jetty/docker/.dockerignore
@@ -1,4 +1,5 @@
 .dockerignore
+.gitignore
 Dockerfile
 conf/README.md
 lib/.gitignore

--- a/dsf-fhir/dsf-fhir-server-jetty/docker/Dockerfile
+++ b/dsf-fhir/dsf-fhir-server-jetty/docker/Dockerfile
@@ -1,12 +1,21 @@
+FROM debian:buster-slim AS builder
+RUN adduser --system --no-create-home --group --uid 2101 java
+WORKDIR /opt/fhir
+COPY --chown=root:java ./ ./
+RUN chown root:java ./ && \
+    chmod 750 ./ ./lib ./dsf_fhir_start.sh && \
+	chmod 640 ./dsf_fhir.jar ./lib/*.jar && \
+	chmod 1775 ./log
+
+
 FROM openjdk:11-slim
-MAINTAINER Hauke Hund <hauke.hund@hs-heilbronn.de>
+LABEL maintainer="hauke.hund@hs-heilbronn.de"
 
 EXPOSE 8080
 
 RUN adduser --system --no-create-home --group --uid 2101 java
 WORKDIR /opt/fhir
-COPY --chown=root:java ./ ./
-RUN chown root:java ./ && chmod 750 ./ ./lib ./dsf_fhir_start.sh && chmod 640 ./dsf_fhir.jar ./lib/*.jar && chmod 1775 ./log
+COPY --from=builder /opt/fhir ./
 
 USER java
 ENTRYPOINT ["./dsf_fhir_start.sh"]


### PR DESCRIPTION
adds missing .gitignore files to .dockerignore
adds --pull options to batch/shell build scripts, making sure we build against latest source images
bpe and fhir app dockerfiles now use multi-stage docker builds to remove an almost identical layer

closes #84 