### PR TITLE
Correct MediaType handling for Binary resources, Prefer: handling... header.

### DIFF
--- a/dsf-bpe/dsf-bpe-process-feasibility/src/main/java/org/highmed/dsf/bpe/service/DownloadFeasibilityResources.java
+++ b/dsf-bpe/dsf-bpe-process-feasibility/src/main/java/org/highmed/dsf/bpe/service/DownloadFeasibilityResources.java
@@ -107,7 +107,7 @@ public class DownloadFeasibilityResources extends AbstractServiceDelegate implem
 	{
 		try
 		{
-			Bundle bundle = client.search(ResearchStudy.class,
+			Bundle bundle = client.searchWithStrictHandling(ResearchStudy.class,
 					Map.of("_id", Collections.singletonList(researchStudyId.getIdPart()), "_include",
 							Collections.singletonList("ResearchStudy:enrollment")));
 

--- a/dsf-bpe/dsf-bpe-process-update-resources/src/test/java/org/highmed/dsf/bpe/start/UpdateResource3MedicTtpExampleStarter.java
+++ b/dsf-bpe/dsf-bpe-process-update-resources/src/test/java/org/highmed/dsf/bpe/start/UpdateResource3MedicTtpExampleStarter.java
@@ -43,7 +43,7 @@ public class UpdateResource3MedicTtpExampleStarter
 		FhirWebserviceClient client = new FhirWebserviceClientJersey("https://ttp/fhir/", trustStore, keyStore,
 				keyStorePassword, null, null, null, 0, 0, null, context, referenceCleaner);
 
-		Bundle searchResult = client.search(Bundle.class, Map.of("identifier",
+		Bundle searchResult = client.searchWithStrictHandling(Bundle.class, Map.of("identifier",
 				Collections.singletonList("http://highmed.org/fhir/CodeSystem/update-whitelist|highmed_whitelist")));
 		if (searchResult.getTotal() != 1 && searchResult.getEntryFirstRep().getResource() instanceof Bundle)
 			throw new IllegalStateException("Expected a single White-List Bundle");

--- a/dsf-bpe/dsf-bpe-process-update-whitelist/src/main/java/org/highmed/dsf/bpe/service/UpdateWhitelist.java
+++ b/dsf-bpe/dsf-bpe-process-update-whitelist/src/main/java/org/highmed/dsf/bpe/service/UpdateWhitelist.java
@@ -60,7 +60,7 @@ public class UpdateWhitelist extends AbstractServiceDelegate implements Initiali
 	{
 		FhirWebserviceClient client = getFhirWebserviceClientProvider().getLocalWebserviceClient();
 
-		Bundle searchSet = client.search(Organization.class,
+		Bundle searchSet = client.searchWithStrictHandling(Organization.class,
 				Map.of("active", Collections.singletonList("true"), "identifier",
 						Collections.singletonList(organizationProvider.getDefaultIdentifierSystem() + "|"), "_include",
 						Collections.singletonList("Organization:endpoint")));

--- a/dsf-bpe/dsf-bpe-server/src/main/java/org/highmed/dsf/fhir/client/FhirClientProviderImpl.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/org/highmed/dsf/fhir/client/FhirClientProviderImpl.java
@@ -172,7 +172,7 @@ public class FhirClientProviderImpl
 
 	private Endpoint searchForEndpoint(String searchParameter, String searchParameterValue)
 	{
-		Bundle resultSet = getLocalWebserviceClient().search(Organization.class,
+		Bundle resultSet = getLocalWebserviceClient().searchWithStrictHandling(Organization.class,
 				Map.of(searchParameter, Collections.singletonList(searchParameterValue), "_include",
 						Collections.singletonList("Organization:endpoint")));
 

--- a/dsf-bpe/dsf-bpe-server/src/main/java/org/highmed/dsf/fhir/organization/OrganizationProviderImpl.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/org/highmed/dsf/fhir/organization/OrganizationProviderImpl.java
@@ -75,7 +75,7 @@ public class OrganizationProviderImpl implements OrganizationProvider, Initializ
 
 	private Stream<Organization> searchForOrganizations(String identifierValue)
 	{
-		Bundle resultSet = clientProvider.getLocalWebserviceClient().search(Organization.class,
+		Bundle resultSet = clientProvider.getLocalWebserviceClient().searchWithStrictHandling(Organization.class,
 				Map.of("active", Collections.singletonList("true"), "identifier",
 						Collections.singletonList(identifierValue)));
 
@@ -112,7 +112,7 @@ public class OrganizationProviderImpl implements OrganizationProvider, Initializ
 	@Override
 	public Stream<Organization> getOrganizationsByType(String type)
 	{
-		Bundle resultSet = clientProvider.getLocalWebserviceClient().search(Organization.class,
+		Bundle resultSet = clientProvider.getLocalWebserviceClient().searchWithStrictHandling(Organization.class,
 				Map.of("active", Collections.singletonList("true"), "type",
 						Collections.singletonList(getDefaultTypeSystem() + "|" + type)));
 

--- a/dsf-bpe/dsf-bpe-server/src/main/java/org/highmed/dsf/fhir/websocket/FhirConnector.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/org/highmed/dsf/fhir/websocket/FhirConnector.java
@@ -106,7 +106,7 @@ public class FhirConnector implements InitializingBean
 	{
 		try
 		{
-			Bundle bundle = clientProvider.getLocalWebserviceClient().search(Subscription.class,
+			Bundle bundle = clientProvider.getLocalWebserviceClient().searchWithStrictHandling(Subscription.class,
 					subscriptionSearchParameter);
 
 			if (!BundleType.SEARCHSET.equals(bundle.getType()))

--- a/dsf-bpe/dsf-bpe-server/src/main/java/org/highmed/dsf/fhir/websocket/PingEventHandler.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/org/highmed/dsf/fhir/websocket/PingEventHandler.java
@@ -74,7 +74,7 @@ public class PingEventHandler implements InitializingBean
 		queryParams.put(PARAM_PAGE, Arrays.asList("1"));
 		queryParams.put(PARAM_SORT, Arrays.asList(PARAM_LAST_UPDATE));
 
-		Bundle bundle = webserviceClient.search(Task.class, queryParams);
+		Bundle bundle = webserviceClient.searchWithStrictHandling(Task.class, queryParams);
 		lastEventTimeIo.writeLastEventTime(LocalDateTime.now());
 
 		if (bundle.getTotal() <= 0)

--- a/dsf-fhir/dsf-fhir-rest-adapter/src/main/java/org/highmed/dsf/fhir/prefer/PreferHandlingType.java
+++ b/dsf-fhir/dsf-fhir-rest-adapter/src/main/java/org/highmed/dsf/fhir/prefer/PreferHandlingType.java
@@ -1,0 +1,33 @@
+package org.highmed.dsf.fhir.prefer;
+
+public enum PreferHandlingType
+{
+	STRICT("handling=strict"), LENIENT("handling=lenient");
+
+	private final String headerValue;
+
+	private PreferHandlingType(String headerValue)
+	{
+		this.headerValue = headerValue;
+	}
+
+	public static PreferHandlingType fromString(String prefer)
+	{
+		if (prefer == null)
+			return LENIENT;
+
+		switch (prefer)
+		{
+			case "handling=strict":
+				return STRICT;
+			case "handling=lenient":
+			default:
+				return LENIENT;
+		}
+	}
+
+	public String getHeaderValue()
+	{
+		return headerValue;
+	}
+}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/help/ResponseGenerator.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/help/ResponseGenerator.java
@@ -161,7 +161,7 @@ public class ResponseGenerator
 		result.getIncludes().stream().map(r -> toBundleEntryComponent(r, SearchEntryMode.INCLUDE))
 				.forEach(bundle::addEntry);
 		if (!errors.isEmpty())
-			bundle.addEntry(toBundleEntryComponent(toOperationOutcome(errors), SearchEntryMode.OUTCOME));
+			bundle.addEntry(toBundleEntryComponent(toOperationOutcomeWarning(errors), SearchEntryMode.OUTCOME));
 
 		bundle.setTotal(result.getOverallCount());
 
@@ -208,10 +208,20 @@ public class ResponseGenerator
 		return bundle;
 	}
 
-	public OperationOutcome toOperationOutcome(List<SearchQueryParameterError> errors)
+	public OperationOutcome toOperationOutcomeWarning(List<SearchQueryParameterError> errors)
+	{
+		return toOperationOutcome(errors, IssueSeverity.WARNING);
+	}
+
+	public OperationOutcome toOperationOutcomeError(List<SearchQueryParameterError> errors)
+	{
+		return toOperationOutcome(errors, IssueSeverity.ERROR);
+	}
+
+	private OperationOutcome toOperationOutcome(List<SearchQueryParameterError> errors, IssueSeverity severity)
 	{
 		String diagnostics = errors.stream().map(SearchQueryParameterError::toString).collect(Collectors.joining("; "));
-		return createOutcome(IssueSeverity.WARNING, IssueType.PROCESSING, diagnostics);
+		return createOutcome(severity, IssueType.PROCESSING, diagnostics);
 	}
 
 	public Response pathVsElementId(String resourceTypeName, String id, IdType resourceId)

--- a/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/webservice/impl/BinaryServiceImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/webservice/impl/BinaryServiceImpl.java
@@ -1,6 +1,7 @@
 package org.highmed.dsf.fhir.webservice.impl;
 
 import java.io.InputStream;
+import java.util.List;
 
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
@@ -20,6 +21,8 @@ import org.highmed.dsf.fhir.service.ReferenceResolver;
 import org.highmed.dsf.fhir.service.ResourceValidator;
 import org.highmed.dsf.fhir.webservice.specification.BinaryService;
 import org.hl7.fhir.r4.model.Binary;
+
+import ca.uhn.fhir.rest.api.Constants;
 
 public class BinaryServiceImpl extends AbstractResourceServiceImpl<BinaryDao, Binary> implements BinaryService
 {
@@ -49,18 +52,24 @@ public class BinaryServiceImpl extends AbstractResourceServiceImpl<BinaryDao, Bi
 	@Override
 	protected MediaType getMediaTypeForRead(UriInfo uri, HttpHeaders headers)
 	{
-		return getMediaType(uri, headers);
+		if (uri.getQueryParameters().containsKey(Constants.PARAM_FORMAT))
+			return super.getMediaTypeForRead(uri, headers);
+		else
+			return getMediaType(uri, headers);
 	}
 
 	@Override
 	protected MediaType getMediaTypeForVRead(UriInfo uri, HttpHeaders headers)
 	{
-		return getMediaType(uri, headers);
+		if (uri.getQueryParameters().containsKey(Constants.PARAM_FORMAT))
+			return super.getMediaTypeForVRead(uri, headers);
+		else
+			return getMediaType(uri, headers);
 	}
 
 	private MediaType getMediaType(UriInfo uri, HttpHeaders headers)
 	{
-		String accept = headers.getHeaderString(HttpHeaders.ACCEPT);
-		return parameterConverter.getMediaTypeIfSupported(uri, headers).orElse(MediaType.valueOf(accept));
+		List<MediaType> types = headers.getAcceptableMediaTypes();
+		return types == null ? null : types.get(0);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/webservice/impl/RootServiceImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/webservice/impl/RootServiceImpl.java
@@ -68,7 +68,7 @@ public class RootServiceImpl extends AbstractBasicService implements RootService
 		referenceCleaner.cleanReferenceResourcesIfBundle(bundle);
 
 		CommandList commands = exceptionHandler.handleBadBundleException(
-				() -> commandFactory.createCommands(bundle, getCurrentUser(), parameterConverter.getPrefer(headers)));
+				() -> commandFactory.createCommands(bundle, getCurrentUser(), parameterConverter.getPreferReturn(headers)));
 
 		Bundle result = commands.execute(); // throws WebApplicationException
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/webservice/secure/AbstractResourceServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/webservice/secure/AbstractResourceServiceSecure.java
@@ -153,7 +153,7 @@ public abstract class AbstractResourceServiceSecure<D extends ResourceDao<R>, R 
 						&& !(created.getEntity() instanceof OperationOutcome))
 					logger.warn("Update returned with entity of type {}", created.getEntity().getClass().getName());
 				else if (!created.hasEntity()
-						&& !PreferReturnType.MINIMAL.equals(parameterConverter.getPrefer(headers)))
+						&& !PreferReturnType.MINIMAL.equals(parameterConverter.getPreferReturn(headers)))
 					logger.warn("Update returned with status {}, but no entity", created.getStatus());
 
 				return created;
@@ -311,7 +311,7 @@ public abstract class AbstractResourceServiceSecure<D extends ResourceDao<R>, R 
 						&& !(updated.getEntity() instanceof OperationOutcome))
 					logger.warn("Update returned with entity of type {}", updated.getEntity().getClass().getName());
 				else if (!updated.hasEntity()
-						&& !PreferReturnType.MINIMAL.equals(parameterConverter.getPrefer(headers)))
+						&& !PreferReturnType.MINIMAL.equals(parameterConverter.getPreferReturn(headers)))
 					logger.warn("Update returned with status {}, but no entity", updated.getStatus());
 
 				return updated;

--- a/dsf-fhir/dsf-fhir-server/src/test/java/org/highmed/dsf/fhir/integration/AbstractIntegrationTest.java
+++ b/dsf-fhir/dsf-fhir-server/src/test/java/org/highmed/dsf/fhir/integration/AbstractIntegrationTest.java
@@ -365,7 +365,7 @@ public abstract class AbstractIntegrationTest
 
 	protected static WebsocketClient getWebsocketClient()
 	{
-		Bundle bundle = getWebserviceClient().search(Subscription.class,
+		Bundle bundle = getWebserviceClient().searchWithStrictHandling(Subscription.class,
 				Map.of("criteria", Collections.singletonList("Task?status=requested"), "status",
 						Collections.singletonList("active"), "type", Collections.singletonList("websocket"), "payload",
 						Collections.singletonList("application/fhir+json")));

--- a/dsf-fhir/dsf-fhir-webservice-client/src/main/java/org/highmed/fhir/client/FhirWebserviceClient.java
+++ b/dsf-fhir/dsf-fhir-webservice-client/src/main/java/org/highmed/fhir/client/FhirWebserviceClient.java
@@ -62,6 +62,8 @@ public interface FhirWebserviceClient extends PreferReturnResource
 
 	Bundle search(Class<? extends Resource> resourceType, Map<String, List<String>> parameters);
 
+	Bundle searchWithStrictHandling(Class<? extends Resource> resourceType, Map<String, List<String>> parameters);
+
 	CapabilityStatement getConformance();
 
 	StructureDefinition generateSnapshot(String url);


### PR DESCRIPTION
* Fixes MediaType (Accept-Header, _format Parameter) handling for Binary resources.
* Implements "Prefer: handling=..." header mechanism for modifying server behavior for handling of unsupported query parameters as defined in [FHIR search API](https://www.hl7.org/fhir/search.html#errors).
* Switches to search with strict error handling were applicable.