### PR TITLE
Issues/103 upgrade dependencies

### DIFF
--- a/dsf-bpe/dsf-bpe-process-base/src/main/java/org/highmed/dsf/fhir/variables/BloomFilterConfigSerializer.java
+++ b/dsf-bpe/dsf-bpe-process-base/src/main/java/org/highmed/dsf/fhir/variables/BloomFilterConfigSerializer.java
@@ -52,7 +52,7 @@ public class BloomFilterConfigSerializer extends PrimitiveValueSerializer<BloomF
 	}
 
 	@Override
-	public BloomFilterConfigValue readValue(ValueFields valueFields)
+	public BloomFilterConfigValue readValue(ValueFields valueFields, boolean asTransientValue)
 	{
 		byte[] bytes = valueFields.getByteArrayValue();
 

--- a/dsf-bpe/dsf-bpe-process-base/src/main/java/org/highmed/dsf/fhir/variables/FeasibilityQueryResultSerializer.java
+++ b/dsf-bpe/dsf-bpe-process-base/src/main/java/org/highmed/dsf/fhir/variables/FeasibilityQueryResultSerializer.java
@@ -52,7 +52,7 @@ public class FeasibilityQueryResultSerializer extends PrimitiveValueSerializer<F
 	}
 
 	@Override
-	public FeasibilityQueryResultValue readValue(ValueFields valueFields)
+	public FeasibilityQueryResultValue readValue(ValueFields valueFields, boolean asTransientValue)
 	{
 		byte[] bytes = valueFields.getByteArrayValue();
 

--- a/dsf-bpe/dsf-bpe-process-base/src/main/java/org/highmed/dsf/fhir/variables/FeasibilityQueryResultsSerializer.java
+++ b/dsf-bpe/dsf-bpe-process-base/src/main/java/org/highmed/dsf/fhir/variables/FeasibilityQueryResultsSerializer.java
@@ -52,7 +52,7 @@ public class FeasibilityQueryResultsSerializer extends PrimitiveValueSerializer<
 	}
 
 	@Override
-	public FeasibilityQueryResultsValue readValue(ValueFields valueFields)
+	public FeasibilityQueryResultsValue readValue(ValueFields valueFields, boolean asTransientValue)
 	{
 		byte[] bytes = valueFields.getByteArrayValue();
 

--- a/dsf-bpe/dsf-bpe-process-base/src/main/java/org/highmed/dsf/fhir/variables/FhirResourceSerializer.java
+++ b/dsf-bpe/dsf-bpe-process-base/src/main/java/org/highmed/dsf/fhir/variables/FhirResourceSerializer.java
@@ -66,7 +66,7 @@ public class FhirResourceSerializer extends PrimitiveValueSerializer<FhirResourc
 	}
 
 	@Override
-	public FhirResourceValue readValue(ValueFields valueFields)
+	public FhirResourceValue readValue(ValueFields valueFields, boolean asTransientValue)
 	{
 		String className = valueFields.getTextValue();
 		byte[] bytes = valueFields.getByteArrayValue();

--- a/dsf-bpe/dsf-bpe-process-base/src/main/java/org/highmed/dsf/fhir/variables/FhirResourcesListSerializer.java
+++ b/dsf-bpe/dsf-bpe-process-base/src/main/java/org/highmed/dsf/fhir/variables/FhirResourcesListSerializer.java
@@ -58,7 +58,7 @@ public class FhirResourcesListSerializer extends PrimitiveValueSerializer<FhirRe
 	}
 
 	@Override
-	public FhirResourcesListValue readValue(ValueFields valueFields)
+	public FhirResourcesListValue readValue(ValueFields valueFields, boolean asTransientValue)
 	{
 		String className = valueFields.getTextValue();
 		byte[] bytes = valueFields.getByteArrayValue();

--- a/dsf-bpe/dsf-bpe-process-base/src/main/java/org/highmed/dsf/fhir/variables/FinalFeasibilityQueryResultSerializer.java
+++ b/dsf-bpe/dsf-bpe-process-base/src/main/java/org/highmed/dsf/fhir/variables/FinalFeasibilityQueryResultSerializer.java
@@ -52,7 +52,7 @@ public class FinalFeasibilityQueryResultSerializer extends PrimitiveValueSeriali
 	}
 
 	@Override
-	public FinalFeasibilityQueryResultValue readValue(ValueFields valueFields)
+	public FinalFeasibilityQueryResultValue readValue(ValueFields valueFields, boolean asTransientValue)
 	{
 		byte[] bytes = valueFields.getByteArrayValue();
 

--- a/dsf-bpe/dsf-bpe-process-base/src/main/java/org/highmed/dsf/fhir/variables/FinalFeasibilityQueryResultsSerializer.java
+++ b/dsf-bpe/dsf-bpe-process-base/src/main/java/org/highmed/dsf/fhir/variables/FinalFeasibilityQueryResultsSerializer.java
@@ -52,7 +52,7 @@ public class FinalFeasibilityQueryResultsSerializer extends PrimitiveValueSerial
 	}
 
 	@Override
-	public FinalFeasibilityQueryResultsValue readValue(ValueFields valueFields)
+	public FinalFeasibilityQueryResultsValue readValue(ValueFields valueFields, boolean asTransientValue)
 	{
 		byte[] bytes = valueFields.getByteArrayValue();
 

--- a/dsf-bpe/dsf-bpe-process-base/src/main/java/org/highmed/dsf/fhir/variables/MultiInstanceTargetSerializer.java
+++ b/dsf-bpe/dsf-bpe-process-base/src/main/java/org/highmed/dsf/fhir/variables/MultiInstanceTargetSerializer.java
@@ -52,7 +52,7 @@ public class MultiInstanceTargetSerializer extends PrimitiveValueSerializer<Mult
 	}
 
 	@Override
-	public MultiInstanceTargetValue readValue(ValueFields valueFields)
+	public MultiInstanceTargetValue readValue(ValueFields valueFields, boolean asTransientValue)
 	{
 		byte[] bytes = valueFields.getByteArrayValue();
 

--- a/dsf-bpe/dsf-bpe-process-base/src/main/java/org/highmed/dsf/fhir/variables/MultiInstanceTargetsSerializer.java
+++ b/dsf-bpe/dsf-bpe-process-base/src/main/java/org/highmed/dsf/fhir/variables/MultiInstanceTargetsSerializer.java
@@ -52,7 +52,7 @@ public class MultiInstanceTargetsSerializer extends PrimitiveValueSerializer<Mul
 	}
 
 	@Override
-	public MultiInstanceTargetsValue readValue(ValueFields valueFields)
+	public MultiInstanceTargetsValue readValue(ValueFields valueFields, boolean asTransientValue)
 	{
 		byte[] bytes = valueFields.getByteArrayValue();
 

--- a/dsf-bpe/dsf-bpe-process-base/src/main/java/org/highmed/dsf/fhir/variables/OutputSerializer.java
+++ b/dsf-bpe/dsf-bpe-process-base/src/main/java/org/highmed/dsf/fhir/variables/OutputSerializer.java
@@ -51,7 +51,7 @@ public class OutputSerializer extends PrimitiveValueSerializer<OutputValue> impl
 	}
 
 	@Override
-	public OutputValue readValue(ValueFields valueFields)
+	public OutputValue readValue(ValueFields valueFields, boolean asTransientValue)
 	{
 		byte[] bytes = valueFields.getByteArrayValue();
 

--- a/dsf-bpe/dsf-bpe-process-base/src/main/java/org/highmed/dsf/fhir/variables/OutputsSerializer.java
+++ b/dsf-bpe/dsf-bpe-process-base/src/main/java/org/highmed/dsf/fhir/variables/OutputsSerializer.java
@@ -51,7 +51,7 @@ public class OutputsSerializer extends PrimitiveValueSerializer<OutputsValue> im
 	}
 
 	@Override
-	public OutputsValue readValue(ValueFields valueFields)
+	public OutputsValue readValue(ValueFields valueFields, boolean asTransientValue)
 	{
 		byte[] bytes = valueFields.getByteArrayValue();
 

--- a/dsf-bpe/dsf-bpe-server-jetty/pom.xml
+++ b/dsf-bpe/dsf-bpe-server-jetty/pom.xml
@@ -34,7 +34,6 @@
 		<dependency>
 			<groupId>javax.mail</groupId>
 			<artifactId>mail</artifactId>
-			<version>1.4.7</version>
 		</dependency>
 	</dependencies>
 

--- a/dsf-bpe/dsf-bpe-server/src/main/resources/db/camunda/postgres_engine_7.12_to_7.13.sql
+++ b/dsf-bpe/dsf-bpe-server/src/main/resources/db/camunda/postgres_engine_7.12_to_7.13.sql
@@ -1,0 +1,63 @@
+--
+-- Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+-- under one or more contributor license agreements. See the NOTICE file
+-- distributed with this work for additional information regarding copyright
+-- ownership. Camunda licenses this file to you under the Apache License,
+-- Version 2.0; you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+insert into ACT_GE_SCHEMA_LOG
+values ('200', CURRENT_TIMESTAMP, '7.13.0');
+
+-- https://jira.camunda.com/browse/CAM-10953
+create index ACT_IDX_HI_VAR_PI_NAME_TYPE on ACT_HI_VARINST(PROC_INST_ID_, NAME_, VAR_TYPE_);
+
+
+-- https://app.camunda.com/jira/browse/CAM-10784
+ALTER TABLE ACT_HI_JOB_LOG
+  ADD HOSTNAME_ varchar(255) default null;
+
+-- https://jira.camunda.com/browse/CAM-10378
+ALTER TABLE ACT_RU_JOB
+  ADD FAILED_ACT_ID_ varchar(255);
+
+ALTER TABLE ACT_HI_JOB_LOG
+  ADD FAILED_ACT_ID_ varchar(255);
+
+ALTER TABLE ACT_RU_INCIDENT
+  ADD FAILED_ACTIVITY_ID_ varchar(255);
+
+ALTER TABLE ACT_HI_INCIDENT
+  ADD FAILED_ACTIVITY_ID_ varchar(255);
+
+-- https://jira.camunda.com/browse/CAM-11616
+ALTER TABLE ACT_RU_AUTHORIZATION
+  ADD REMOVAL_TIME_ timestamp;
+create index ACT_IDX_AUTH_RM_TIME on ACT_RU_AUTHORIZATION(REMOVAL_TIME_);
+
+-- https://jira.camunda.com/browse/CAM-11616
+ALTER TABLE ACT_RU_AUTHORIZATION
+  ADD ROOT_PROC_INST_ID_ varchar(64);
+create index ACT_IDX_AUTH_ROOT_PI on ACT_RU_AUTHORIZATION(ROOT_PROC_INST_ID_);
+
+-- https://jira.camunda.com/browse/CAM-11188
+ALTER TABLE ACT_RU_JOBDEF
+  ADD DEPLOYMENT_ID_ varchar(64);
+
+
+-- https://jira.camunda.com/browse/CAM-10978
+
+ALTER TABLE ACT_RU_VARIABLE
+  ADD PROC_DEF_ID_ varchar(64);
+
+ALTER TABLE ACT_HI_DETAIL
+  ADD INITIAL_ boolean;

--- a/dsf-bpe/dsf-bpe-server/src/main/resources/db/db.camunda_engine.changelog-0.2.0.xml
+++ b/dsf-bpe/dsf-bpe-server/src/main/resources/db/db.camunda_engine.changelog-0.2.0.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+	xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
+
+	<changeSet author="camunda.org" id="db.camunda_engine.changelog-0.2.0">
+		<sqlFile dbms="postgresql" encoding="utf8" path="db/camunda/postgres_engine_7.12_to_7.13.sql" />
+	</changeSet>
+
+</databaseChangeLog>

--- a/dsf-bpe/dsf-bpe-server/src/main/resources/db/db.changelog.xml
+++ b/dsf-bpe/dsf-bpe-server/src/main/resources/db/db.changelog.xml
@@ -9,4 +9,6 @@
 	<include file="db/db.camunda_engine.changelog-0.1.0.xml" />
 	<include file="db/db.camunda_identity.changelog-0.1.0.xml" />
 
+	<include file="db/db.camunda_engine.changelog-0.2.0.xml" />
+
 </databaseChangeLog>

--- a/dsf-bpe/pom.xml
+++ b/dsf-bpe/pom.xml
@@ -25,7 +25,7 @@
 
 	<properties>
 		<!-- if upgrading, copy version specific camunda sql scripts to dsf-bpe-server/src/main/resource/db/camunda and create a corresponding liquibase migration script -->
-		<camunda.version>7.12.0</camunda.version>
+		<camunda.version>7.13.0</camunda.version>
 	</properties>
 
 	<repositories>
@@ -176,11 +176,6 @@
 				<version>${camunda.version}</version>
 				<scope>import</scope>
 				<type>pom</type>
-			</dependency>
-			<dependency>
-				<groupId>org.mybatis</groupId>
-				<artifactId>mybatis</artifactId>
-				<version>3.5.5</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/dsf-bpe/pom.xml
+++ b/dsf-bpe/pom.xml
@@ -180,7 +180,7 @@
 			<dependency>
 				<groupId>org.mybatis</groupId>
 				<artifactId>mybatis</artifactId>
-				<version>3.5.3</version>
+				<version>3.5.5</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/dsf-docker-test-setup-3medic-ttp/highmed.yml
+++ b/dsf-docker-test-setup-3medic-ttp/highmed.yml
@@ -67,9 +67,9 @@
          append: true
    -  name: Download docker-compose
       get_url:
-         url: https://github.com/docker/compose/releases/download/1.25.5/docker-compose-Linux-x86_64
+         url: https://github.com/docker/compose/releases/download/1.26.0/docker-compose-Linux-x86_64
          dest: /usr/local/bin/docker-compose
-         checksum: sha256:1cb7ecccc17c8d5f1888f9e2b3211b07e35c86d0010a6c0f711fe65ef5b69528
+         checksum: sha256:ff6816932a57eab448798105926adbe4363b82f217802b105ade2edad95706cb
          mode: '777'
    -  name: update /etc/hosts file
       blockinfile:

--- a/dsf-fhir/dsf-fhir-server-jetty/pom.xml
+++ b/dsf-fhir/dsf-fhir-server-jetty/pom.xml
@@ -46,7 +46,6 @@
 		<dependency>
 			<groupId>javax.mail</groupId>
 			<artifactId>mail</artifactId>
-			<version>1.4.7</version>
 		</dependency>
 	</dependencies>
 

--- a/dsf-fhir/dsf-fhir-server/pom.xml
+++ b/dsf-fhir/dsf-fhir-server/pom.xml
@@ -159,11 +159,11 @@
 			<artifactId>log4j2-utils</artifactId>
 			<scope>runtime</scope>
 		</dependency>
-
+		
+		<!-- For async logging with log4j2 -->
 		<dependency>
 			<groupId>com.lmax</groupId>
 			<artifactId>disruptor</artifactId>
-			<version>3.4.2</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/dsf-fhir/dsf-fhir-websocket-client/src/main/java/org/highmed/fhir/client/ClientEndpoint.java
+++ b/dsf-fhir/dsf-fhir-websocket-client/src/main/java/org/highmed/fhir/client/ClientEndpoint.java
@@ -3,17 +3,17 @@ package org.highmed.fhir.client;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-import javax.websocket.CloseReason;
-import javax.websocket.Endpoint;
-import javax.websocket.EndpointConfig;
-import javax.websocket.MessageHandler.Whole;
-import javax.websocket.Session;
-
 import org.hl7.fhir.r4.model.DomainResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import ca.uhn.fhir.parser.IParser;
+
+import javax.websocket.CloseReason;
+import javax.websocket.Endpoint;
+import javax.websocket.EndpointConfig;
+import javax.websocket.MessageHandler;
+import javax.websocket.Session;
 
 public class ClientEndpoint extends Endpoint
 {
@@ -35,7 +35,7 @@ public class ClientEndpoint extends Endpoint
 	{
 		logger.debug("Websocket onOpen");
 
-		session.addMessageHandler(new Whole<String>() // don't use lambda
+		session.addMessageHandler(new MessageHandler.Whole<String>() // don't use lambda
 		{
 			private boolean boundReceived;
 

--- a/dsf-fhir/dsf-fhir-websocket-client/src/main/java/org/highmed/fhir/client/WebsocketClientTyrus.java
+++ b/dsf-fhir/dsf-fhir-websocket-client/src/main/java/org/highmed/fhir/client/WebsocketClientTyrus.java
@@ -7,9 +7,7 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import javax.net.ssl.SSLContext;
-import javax.websocket.CloseReason;
-import javax.websocket.DeploymentException;
-import javax.websocket.Session;
+
 
 import org.glassfish.jersey.SslConfigurator;
 import org.glassfish.tyrus.client.ClientManager;
@@ -21,6 +19,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import ca.uhn.fhir.parser.IParser;
+
+import javax.websocket.CloseReason;
+import javax.websocket.DeploymentException;
+import javax.websocket.Session;
 
 public class WebsocketClientTyrus implements WebsocketClient
 {

--- a/dsf-mpi/pom.xml
+++ b/dsf-mpi/pom.xml
@@ -41,10 +41,14 @@
 			</dependency>
 			<dependency>
 				<groupId>org.highmed.dsf</groupId>
+				<artifactId>dsf-mpi-client-stub</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.highmed.dsf</groupId>
 				<artifactId>dsf-mpi-client-pdq</artifactId>
 				<version>${project.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
-
 </project>

--- a/dsf-pseudonymization/dsf-pseudonymization-ttp/pom.xml
+++ b/dsf-pseudonymization/dsf-pseudonymization-ttp/pom.xml
@@ -37,7 +37,7 @@
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
 			<artifactId>bcprov-jdk15on</artifactId>
-			<version>1.65.01</version>
+			<version>1.65</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/dsf-pseudonymization/dsf-pseudonymization-ttp/pom.xml
+++ b/dsf-pseudonymization/dsf-pseudonymization-ttp/pom.xml
@@ -48,7 +48,6 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-csv</artifactId>
-			<version>1.8</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/dsf-pseudonymization/dsf-pseudonymization-ttp/pom.xml
+++ b/dsf-pseudonymization/dsf-pseudonymization-ttp/pom.xml
@@ -37,7 +37,7 @@
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
 			<artifactId>bcprov-jdk15on</artifactId>
-			<version>1.64</version>
+			<version>1.65.01</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-csv</artifactId>
-			<version>1.7</version>
+			<version>1.8</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/dsf-pseudonymization/pom.xml
+++ b/dsf-pseudonymization/pom.xml
@@ -21,7 +21,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.10.1</version>
+			<version>2.11.1</version>
 		</dependency>
 
 		<!-- Logging -->

--- a/dsf-pseudonymization/pom.xml
+++ b/dsf-pseudonymization/pom.xml
@@ -21,7 +21,6 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.11.1</version>
 		</dependency>
 
 		<!-- Logging -->

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 		<compileSource>11</compileSource>
 		<compileTarget>11</compileTarget>
 
-		<slf4j.version>2.0.0-alpha1</slf4j.version>
+		<slf4j.version>1.8.0-beta4</slf4j.version>
 		<log4j.version>2.13.3</log4j.version>
 
 		<jetty.version>9.4.30.v20200611</jetty.version>
@@ -111,7 +111,7 @@
 			<dependency>
 				<groupId>org.postgresql</groupId>
 				<artifactId>postgresql</artifactId>
-				<version>42.2.14.jre7</version>
+				<version>42.2.14</version>
 			</dependency>
 
 			<!-- hhn rwh -->
@@ -200,7 +200,7 @@
 			<dependency>
 				<groupId>org.glassfish.jaxb</groupId>
 				<artifactId>jaxb-runtime</artifactId>
-				<version>3.0.0-M4</version>
+				<version>2.3.3</version>
 			</dependency>
 
 			<!-- spring -->

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,18 @@
 				<artifactId>log4j-core</artifactId>
 				<version>${log4j.version}</version>
 			</dependency>
+			<!-- async logging -->
+			<dependency>
+				<groupId>com.lmax</groupId>
+				<artifactId>disruptor</artifactId>
+				<version>3.4.2</version>
+			</dependency>
+			<!-- smtp appender -->
+			<dependency>
+				<groupId>javax.mail</groupId>
+				<artifactId>mail</artifactId>
+				<version>1.4.7</version>
+			</dependency>
 
 			<!-- testing -->
 			<dependency>
@@ -182,6 +194,11 @@
 				<groupId>org.glassfish.jersey.media</groupId>
 				<artifactId>jersey-media-json-jackson</artifactId>
 				<version>${jersey.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.fasterxml.jackson.core</groupId>
+				<artifactId>jackson-databind</artifactId>
+				<version>2.11.1</version>
 			</dependency>
 
 			<!-- tyrus -->
@@ -294,6 +311,12 @@
 				<groupId>ca.uhn.hapi</groupId>
 				<artifactId>hapi-structures-v25</artifactId>
 				<version>${hapi.hl7v2.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.apache.commons</groupId>
+				<artifactId>commons-csv</artifactId>
+				<version>1.8</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -21,13 +21,13 @@
 		<compileSource>11</compileSource>
 		<compileTarget>11</compileTarget>
 
-		<slf4j.version>1.8.0-beta4</slf4j.version>
-		<log4j.version>2.13.0</log4j.version>
+		<slf4j.version>2.0.0-alpha1</slf4j.version>
+		<log4j.version>2.13.3</log4j.version>
 
 		<jetty.version>9.4.26.v20200117</jetty.version>
 		<jersey.version>2.30.1</jersey.version>
 		<tyrus.version>1.15</tyrus.version>
-		<spring.version>5.2.3.RELEASE</spring.version>
+		<spring.version>5.2.7.RELEASE</spring.version>
 
 		<hapi.fhir.version>5.0.2</hapi.fhir.version>
 		<hapi.hl7v2.version>2.3</hapi.hl7v2.version>
@@ -94,7 +94,7 @@
 			<dependency>
 				<groupId>org.mockito</groupId>
 				<artifactId>mockito-core</artifactId>
-				<version>3.1.0</version>
+				<version>3.3.3</version>
 			</dependency>
 
 			<!-- database -->
@@ -111,29 +111,29 @@
 			<dependency>
 				<groupId>org.postgresql</groupId>
 				<artifactId>postgresql</artifactId>
-				<version>42.2.10</version>
+				<version>42.2.14.jre7</version>
 			</dependency>
 
 			<!-- hhn rwh -->
 			<dependency>
 				<groupId>de.hs-heilbronn.mi</groupId>
 				<artifactId>jetty-utils</artifactId>
-				<version>0.6.0</version>
+				<version>0.7.0</version>
 			</dependency>
 			<dependency>
 				<groupId>de.hs-heilbronn.mi</groupId>
 				<artifactId>crypto-utils</artifactId>
-				<version>2.4.0</version>
+				<version>2.5.0</version>
 			</dependency>
 			<dependency>
 				<groupId>de.hs-heilbronn.mi</groupId>
 				<artifactId>log4j2-utils</artifactId>
-				<version>0.5.0</version>
+				<version>0.6.0</version>
 			</dependency>
 			<dependency>
 				<groupId>de.hs-heilbronn.mi</groupId>
 				<artifactId>db-test-utils</artifactId>
-				<version>0.6.0</version>
+				<version>0.7.0</version>
 			</dependency>
 
 			<dependency>
@@ -200,7 +200,7 @@
 			<dependency>
 				<groupId>org.glassfish.jaxb</groupId>
 				<artifactId>jaxb-runtime</artifactId>
-				<version>2.3.2</version>
+				<version>3.0.0-M4</version>
 			</dependency>
 
 			<!-- spring -->

--- a/pom.xml
+++ b/pom.xml
@@ -330,7 +330,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-war-plugin</artifactId>
-					<version>3.2.3</version>
+					<version>3.3.0</version>
 					<configuration>
 						<archive>
 							<manifest>
@@ -347,27 +347,27 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-source-plugin</artifactId>
-					<version>3.2.0</version>
+					<version>3.2.1</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-javadoc-plugin</artifactId>
-					<version>3.1.1</version>
+					<version>3.2.0</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
-					<version>3.0.0-M4</version>
+					<version>3.0.0-M5</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-shade-plugin</artifactId>
-					<version>3.2.2</version>
+					<version>3.2.4</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-assembly-plugin</artifactId>
-					<version>3.2.0</version>
+					<version>3.3.0</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
@@ -382,7 +382,7 @@
 				<plugin>
 					<groupId>org.codehaus.mojo</groupId>
 					<artifactId>exec-maven-plugin</artifactId>
-					<version>1.6.0</version>
+					<version>3.0.0</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
 			<dependency>
 				<groupId>org.liquibase</groupId>
 				<artifactId>liquibase-core</artifactId>
-				<version>3.8.7</version>
+				<version>3.10.0</version>
 			</dependency>
 			<dependency>
 				<groupId>org.postgresql</groupId>
@@ -118,22 +118,22 @@
 			<dependency>
 				<groupId>de.hs-heilbronn.mi</groupId>
 				<artifactId>jetty-utils</artifactId>
-				<version>0.7.0</version>
+				<version>0.8.0</version>
 			</dependency>
 			<dependency>
 				<groupId>de.hs-heilbronn.mi</groupId>
 				<artifactId>crypto-utils</artifactId>
-				<version>2.5.0</version>
+				<version>2.6.0</version>
 			</dependency>
 			<dependency>
 				<groupId>de.hs-heilbronn.mi</groupId>
 				<artifactId>log4j2-utils</artifactId>
-				<version>0.6.0</version>
+				<version>0.7.0</version>
 			</dependency>
 			<dependency>
 				<groupId>de.hs-heilbronn.mi</groupId>
 				<artifactId>db-test-utils</artifactId>
-				<version>0.7.0</version>
+				<version>0.8.0</version>
 			</dependency>
 
 			<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -24,9 +24,9 @@
 		<slf4j.version>2.0.0-alpha1</slf4j.version>
 		<log4j.version>2.13.3</log4j.version>
 
-		<jetty.version>9.4.26.v20200117</jetty.version>
-		<jersey.version>2.30.1</jersey.version>
-		<tyrus.version>1.15</tyrus.version>
+		<jetty.version>9.4.30.v20200611</jetty.version>
+		<jersey.version>2.31</jersey.version>
+		<tyrus.version>1.17</tyrus.version>
 		<spring.version>5.2.7.RELEASE</spring.version>
 
 		<hapi.fhir.version>5.0.2</hapi.fhir.version>


### PR DESCRIPTION
upgrades dependency versions:
* camunda 7.12 -> 7.13
* bouncycastle 1.64 -> 1.65
* commons-csv 1.7 -> 1.8
* jackson-databind 2.10.1 -> 2.11.1
* log4j 2.13.0 -> 2.13.3
* jetty 9.4.26.v20200117 -> 9.4.30.v20200611
* jersey 2.30.1 -> 2.31
* tyrus 1.15 -> 1.17
* spring 5.2.3.RELEASE -> 5.2.7.RELEASE
* mockito-core 3.1.0 -> 3.3.3
* liquibase-core 3.8.7 -> 3.10.0
* postgresql 42.2.10 -> 42.2.14
* jetty-utils 0.6.0 -> 0.8.0
* crypto-utils 2.4.0 -> 2.6.0
* log4j2-utils 0.5.0 -> 0.7.0
* db-test-utils 0.6.0 -> 0.8.0
* jaxb-runtime 2.3.2 -> 2.3.3

upgraded maven plugins:
* maven-war-plugin 3.2.3 -> 3.3.0
* maven-source-plugin 3.2.0 -> 3.2.1
* maven-javadoc-plugin 3.1.1 -> 3.2.0
* maven-surefire-plugin 3.0.0-M4 -> 3.0.0-M5
* maven-shade-plugin 3.2.2 -> 3.2.4
* maven-assembly-plugin 3.2.0 -> 3.3.0
* exec-maven-plugin 1.6.0 -> 3.0.0

upgrades docker-compose via ansible script higmed.yml in test setup: 1.25.5 -> 1.26.0

Closes #103 