### PR TITLE
Fix for High CPU Load on BPE Server After FHIR Server Restart

### DIFF
--- a/dsf-bpe/dsf-bpe-server-jetty/docker/dsf_bpe_start.sh
+++ b/dsf-bpe/dsf-bpe-server-jetty/docker/dsf_bpe_start.sh
@@ -4,7 +4,7 @@ echo "Executing DSF BPE with"
 java --version
 
 trap 'kill -TERM $PID' TERM INT
-java -cp lib/*:plugin/*:dsf_bpe.jar org.highmed.dsf.bpe.BpeJettyServer &
+java $EXTRA_JVM_ARGS -Djdk.tls.acknowledgeCloseNotify=true -cp lib/*:plugin/*:dsf_bpe.jar org.highmed.dsf.bpe.BpeJettyServer &
 PID=$!
 wait $PID
 trap - TERM INT

--- a/dsf-docker-test-setup/bpe/docker-compose.yml
+++ b/dsf-docker-test-setup/bpe/docker-compose.yml
@@ -21,6 +21,10 @@ services:
    app:
       image: highmed/bpe
       restart: on-failure
+# Ports for jmx debug connections
+#      ports:
+#      - 9020:9020
+#      - 9021:9021
       volumes:
       -  type: bind
          source: ./app/conf
@@ -38,6 +42,8 @@ services:
          target: /opt/bpe/last_event
       environment:
          TZ: Europe/Berlin
+# Use EXTRA_JVM_ARGS to specify special jvm parameters, e.g. jmx connection config below
+#         EXTRA_JVM_ARGS: -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=9020 -Dcom.sun.management.jmxremote.rmi.port=9021 -Djava.rmi.server.hostname=localhost -Dcom.sun.management.jmxremote.local.only=false
       networks:
          frontend:
             ipv4_address: 172.28.3.3

--- a/dsf-docker-test-setup/fhir/docker-compose.yml
+++ b/dsf-docker-test-setup/fhir/docker-compose.yml
@@ -25,6 +25,10 @@ services:
    app:
       image: highmed/fhir
       restart: on-failure
+ # Ports for jmx debug connections
+ #     ports:
+ #     - 9010:9010
+ #     - 9011:9011
       volumes:
       -  type: bind
          source: ./app/conf
@@ -34,6 +38,8 @@ services:
          target: /opt/fhir/log
       environment:
          TZ: Europe/Berlin
+# Use EXTRA_JVM_ARGS to specify special jvm parameters, e.g. jmx connection config below
+#         EXTRA_JVM_ARGS: -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.rmi.port=9011 -Djava.rmi.server.hostname=localhost -Dcom.sun.management.jmxremote.local.only=false
       networks:
          frontend:
             ipv4_address: 172.28.1.3

--- a/dsf-fhir/dsf-fhir-server-jetty/docker/dsf_fhir_start.sh
+++ b/dsf-fhir/dsf-fhir-server-jetty/docker/dsf_fhir_start.sh
@@ -4,7 +4,7 @@ echo "Executing DSF FHIR with"
 java --version
 
 trap 'kill -TERM $PID' TERM INT
-java -cp lib/*:dsf_fhir.jar org.highmed.dsf.fhir.FhirJettyServer &
+java $EXTRA_JVM_ARGS -Djdk.tls.acknowledgeCloseNotify=true -cp lib/*:dsf_fhir.jar org.highmed.dsf.fhir.FhirJettyServer &
 PID=$!
 wait $PID
 trap - TERM INT


### PR DESCRIPTION
- Adds JVM property `jdk.tls.acknowledgeCloseNotify=true` as a TLS 1.3 connection close issue workaround.
- Adds extra JVM arguments environment variable `EXTRA_JVM_ARGS` to specify for example jmx connection properties.

Closes #112 