### PR TITLE
Issues/123 Missing fields in openEhr Request

### DIFF
--- a/dsf-openehr/dsf-openehr-client-impl/src/main/java/org/highmed/openehr/client/impl/OpenEhrClientJersey.java
+++ b/dsf-openehr/dsf-openehr-client-impl/src/main/java/org/highmed/openehr/client/impl/OpenEhrClientJersey.java
@@ -40,7 +40,7 @@ public class OpenEhrClientJersey extends AbstractJerseyClient implements OpenEhr
 	{
 		Response response = getResource().path(OPENEHR_QUERY_PATH).request().headers(headers)
 				.header("Accept", MediaType.APPLICATION_JSON).header("Content-Type", MediaType.APPLICATION_JSON)
-				.post(Entity.entity(new Request(query, null, null, null), MediaType.APPLICATION_JSON));
+				.post(Entity.entity(new Request(query, null, null, null, null), MediaType.APPLICATION_JSON));
 
 		logger.debug("HTTP {}: {}", response.getStatusInfo().getStatusCode(),
 				response.getStatusInfo().getReasonPhrase());

--- a/dsf-openehr/dsf-openehr-model/src/main/java/org/highmed/openehr/model/structure/Request.java
+++ b/dsf-openehr/dsf-openehr-model/src/main/java/org/highmed/openehr/model/structure/Request.java
@@ -13,20 +13,23 @@ public class Request
 {
 	@JsonProperty("q")
 	private final String query;
+	@JsonProperty("ehr_id")
+	private final String ehrId;
 
 	@JsonProperty("offset")
 	private final String offset;
 	@JsonProperty("fetch")
 	private final String fetch;
 
-	@JsonProperty("query-parameters")
+	@JsonProperty("query_parameters")
 	private final Map<String, Object> queryParameters = new HashMap<>();
 
 	@JsonCreator
-	public Request(@JsonProperty("q") String query, @JsonProperty("offset") String offset,
-			@JsonProperty("fetch") String fetch, @JsonProperty("query-parameters") Map<String, Object> queryParameters)
+	public Request(@JsonProperty("q") String query, @JsonProperty("ehr_id") String ehrId, @JsonProperty("offset") String offset,
+			@JsonProperty("fetch") String fetch, @JsonProperty("query_parameters") Map<String, Object> queryParameters)
 	{
 		this.query = query;
+		this.ehrId = ehrId;
 		this.offset = offset;
 		this.fetch = fetch;
 
@@ -37,6 +40,11 @@ public class Request
 	public String getQuery()
 	{
 		return query;
+	}
+
+	public String getEhrId()
+	{
+		return ehrId;
 	}
 
 	public String getOffset()


### PR DESCRIPTION
* Adds missing field `ehr_id` to openEhr request
* Fixes typo in JsonProperty annotation of field `query_parameters`

closes #123