### PR TITLE
Retry FHIR Client

### DIFF
--- a/dsf-fhir/dsf-fhir-webservice-client/src/main/java/org/highmed/fhir/client/AbstractFhirWebserviceClientJerseyWithRetry.java
+++ b/dsf-fhir/dsf-fhir-webservice-client/src/main/java/org/highmed/fhir/client/AbstractFhirWebserviceClientJerseyWithRetry.java
@@ -1,0 +1,114 @@
+package org.highmed.fhir.client;
+
+import java.util.function.Supplier;
+
+import javax.ws.rs.ProcessingException;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response.Status;
+
+import org.apache.http.conn.ConnectTimeoutException;
+import org.apache.http.conn.HttpHostConnectException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class AbstractFhirWebserviceClientJerseyWithRetry
+{
+	private static final Logger logger = LoggerFactory.getLogger(AbstractFhirWebserviceClientJerseyWithRetry.class);
+
+	protected final FhirWebserviceClientJersey delegate;
+	protected final int nTimes;
+	protected final long delayMillis;
+
+	protected AbstractFhirWebserviceClientJerseyWithRetry(FhirWebserviceClientJersey delegate, int nTimes,
+			long delayMillis)
+	{
+		this.delegate = delegate;
+		this.nTimes = nTimes;
+		this.delayMillis = delayMillis;
+	}
+
+	protected final <R> R retry(int nTimes, long delayMillis, Supplier<R> supplier)
+	{
+		if (nTimes < 0)
+			throw new IllegalArgumentException("nTimes < 0");
+		if (delayMillis < 0)
+			throw new IllegalArgumentException("delayMillis < 0");
+
+		RuntimeException caughtException = null;
+		for (int tryNumber = 0; tryNumber <= nTimes; tryNumber++)
+		{
+			try
+			{
+				if (tryNumber == 0)
+					logger.debug("First try ...");
+				else
+					logger.debug("Retry {} of {}", tryNumber, nTimes);
+
+				return supplier.get();
+			}
+			catch (ProcessingException | WebApplicationException e)
+			{
+				if (shouldRetry(e))
+				{
+					if ((tryNumber) < nTimes)
+					{
+						logger.warn("Caught {}: {}; trying again in {} ms", e.getClass(), e.getMessage(), delayMillis);
+
+						try
+						{
+							Thread.sleep(delayMillis);
+						}
+						catch (InterruptedException e1)
+						{
+						}
+					}
+					else
+					{
+						logger.warn("Caught {}: {}; not trying again", e.getClass(), e.getMessage(), delayMillis);
+					}
+
+					if (caughtException != null)
+						e.addSuppressed(caughtException);
+					caughtException = e;
+				}
+				else
+					throw e;
+			}
+		}
+
+		throw caughtException;
+	}
+
+	private boolean shouldRetry(RuntimeException e)
+	{
+		if (e instanceof WebApplicationException)
+		{
+			return isRetryStatusCode((WebApplicationException) e);
+		}
+		else if (e instanceof ProcessingException)
+		{
+			Throwable cause = e;
+			if (isRetryCause(cause))
+				return true;
+
+			while (cause.getCause() != null)
+			{
+				cause = cause.getCause();
+				if (isRetryCause(cause))
+					return true;
+			}
+		}
+
+		return false;
+	}
+
+	private boolean isRetryStatusCode(WebApplicationException e)
+	{
+		return Status.Family.SERVER_ERROR.equals(e.getResponse().getStatusInfo().getFamily());
+	}
+
+	private boolean isRetryCause(Throwable cause)
+	{
+		return cause instanceof ConnectTimeoutException || cause instanceof HttpHostConnectException;
+	}
+}

--- a/dsf-fhir/dsf-fhir-webservice-client/src/main/java/org/highmed/fhir/client/BasicFhirWebserviceCientWithRetryImpl.java
+++ b/dsf-fhir/dsf-fhir-webservice-client/src/main/java/org/highmed/fhir/client/BasicFhirWebserviceCientWithRetryImpl.java
@@ -1,0 +1,170 @@
+package org.highmed.fhir.client;
+
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import javax.ws.rs.core.MediaType;
+
+import org.hl7.fhir.r4.model.Binary;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.CapabilityStatement;
+import org.hl7.fhir.r4.model.IdType;
+import org.hl7.fhir.r4.model.Resource;
+import org.hl7.fhir.r4.model.StructureDefinition;
+
+class BasicFhirWebserviceCientWithRetryImpl extends AbstractFhirWebserviceClientJerseyWithRetry
+		implements BasicFhirWebserviceClient
+{
+	BasicFhirWebserviceCientWithRetryImpl(FhirWebserviceClientJersey delegate, int nTimes, long delayMillis)
+	{
+		super(delegate, nTimes, delayMillis);
+	}
+
+	@Override
+	public <R extends Resource> R updateConditionaly(R resource, Map<String, List<String>> criteria)
+	{
+		return retry(nTimes, delayMillis, () -> delegate.updateConditionaly(resource, criteria));
+	}
+
+	@Override
+	public Binary updateBinary(String id, InputStream in, MediaType mediaType, String securityContextReference)
+	{
+		return retry(nTimes, delayMillis, () -> delegate.updateBinary(id, in, mediaType, securityContextReference));
+	}
+
+	@Override
+	public <R extends Resource> R update(R resource)
+	{
+		return retry(nTimes, delayMillis, () -> delegate.update(resource));
+	}
+
+	@Override
+	public Bundle postBundle(Bundle bundle)
+	{
+		return retry(nTimes, delayMillis, () -> delegate.postBundle(bundle));
+	}
+
+	@Override
+	public <R extends Resource> R createConditionaly(R resource, String ifNoneExistCriteria)
+	{
+		return retry(nTimes, delayMillis, () -> delegate.createConditionaly(resource, ifNoneExistCriteria));
+	}
+
+	@Override
+	public Binary createBinary(InputStream in, MediaType mediaType, String securityContextReference)
+	{
+		return retry(nTimes, delayMillis, () -> delegate.createBinary(in, mediaType, securityContextReference));
+	}
+
+	@Override
+	public <R extends Resource> R create(R resource)
+	{
+		return retry(nTimes, delayMillis, () -> delegate.create(resource));
+	}
+
+	@Override
+	public Bundle searchWithStrictHandling(Class<? extends Resource> resourceType, Map<String, List<String>> parameters)
+	{
+		return retry(nTimes, delayMillis, () -> delegate.searchWithStrictHandling(resourceType, parameters));
+	}
+
+	@Override
+	public Bundle search(Class<? extends Resource> resourceType, Map<String, List<String>> parameters)
+	{
+		return retry(nTimes, delayMillis, () -> delegate.search(resourceType, parameters));
+	}
+
+	@Override
+	public InputStream readBinary(String id, String version, MediaType mediaType)
+	{
+		return retry(nTimes, delayMillis, () -> delegate.readBinary(id, version, mediaType));
+	}
+
+	@Override
+	public InputStream readBinary(String id, MediaType mediaType)
+	{
+		return retry(nTimes, delayMillis, () -> delegate.readBinary(id, mediaType));
+	}
+
+	@Override
+	public <R extends Resource> R read(Class<R> resourceType, String id, String version)
+	{
+		return retry(nTimes, delayMillis, () -> delegate.read(resourceType, id, version));
+	}
+
+	@Override
+	public Resource read(String resourceTypeName, String id, String version)
+	{
+		return retry(nTimes, delayMillis, () -> delegate.read(resourceTypeName, id, version));
+	}
+
+	@Override
+	public <R extends Resource> R read(Class<R> resourceType, String id)
+	{
+		return retry(nTimes, delayMillis, () -> delegate.read(resourceType, id));
+	}
+
+	@Override
+	public Resource read(String resourceTypeName, String id)
+	{
+		return retry(nTimes, delayMillis, () -> delegate.read(resourceTypeName, id));
+	}
+
+	@Override
+	public CapabilityStatement getConformance()
+	{
+		return retry(nTimes, delayMillis, () -> delegate.getConformance());
+	}
+
+	@Override
+	public StructureDefinition generateSnapshot(StructureDefinition differential)
+	{
+		return retry(nTimes, delayMillis, () -> delegate.generateSnapshot(differential));
+	}
+
+	@Override
+	public StructureDefinition generateSnapshot(String url)
+	{
+		return retry(nTimes, delayMillis, () -> delegate.generateSnapshot(url));
+	}
+
+	@Override
+	public boolean exists(IdType resourceTypeIdVersion)
+	{
+		return retry(nTimes, delayMillis, () -> delegate.exists(resourceTypeIdVersion));
+	}
+
+	@Override
+	public <R extends Resource> boolean exists(Class<R> resourceType, String id, String version)
+	{
+		return retry(nTimes, delayMillis, () -> delegate.exists(resourceType, id, version));
+	}
+
+	@Override
+	public <R extends Resource> boolean exists(Class<R> resourceType, String id)
+	{
+		return retry(nTimes, delayMillis, () -> delegate.exists(resourceType, id));
+	}
+
+	@Override
+	public void deleteConditionaly(Class<? extends Resource> resourceClass, Map<String, List<String>> criteria)
+	{
+		retry(nTimes, delayMillis, (Supplier<Void>) () ->
+		{
+			delegate.deleteConditionaly(resourceClass, criteria);
+			return null;
+		});
+	}
+
+	@Override
+	public void delete(Class<? extends Resource> resourceClass, String id)
+	{
+		retry(nTimes, delayMillis, (Supplier<Void>) () ->
+		{
+			delegate.delete(resourceClass, id);
+			return null;
+		});
+	}
+}

--- a/dsf-fhir/dsf-fhir-webservice-client/src/main/java/org/highmed/fhir/client/BasicFhirWebserviceClient.java
+++ b/dsf-fhir/dsf-fhir-webservice-client/src/main/java/org/highmed/fhir/client/BasicFhirWebserviceClient.java
@@ -1,0 +1,66 @@
+package org.highmed.fhir.client;
+
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+
+import javax.ws.rs.core.MediaType;
+
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.CapabilityStatement;
+import org.hl7.fhir.r4.model.IdType;
+import org.hl7.fhir.r4.model.Resource;
+import org.hl7.fhir.r4.model.StructureDefinition;
+
+public interface BasicFhirWebserviceClient extends PreferReturnResource
+{
+	void delete(Class<? extends Resource> resourceClass, String id);
+
+	void deleteConditionaly(Class<? extends Resource> resourceClass, Map<String, List<String>> criteria);
+
+	Resource read(String resourceTypeName, String id);
+
+	<R extends Resource> R read(Class<R> resourceType, String id);
+
+	<R extends Resource> boolean exists(Class<R> resourceType, String id);
+
+	InputStream readBinary(String id, MediaType mediaType);
+
+	/**
+	 * @param resourceTypeName
+	 *            not <code>null</code>
+	 * @param id
+	 *            not <code>null</code>
+	 * @param version
+	 *            not <code>null</code>
+	 * @return {@link InputStream} needs to be closed
+	 */
+	Resource read(String resourceTypeName, String id, String version);
+
+	<R extends Resource> R read(Class<R> resourceType, String id, String version);
+
+	<R extends Resource> boolean exists(Class<R> resourceType, String id, String version);
+
+	/**
+	 * @param id
+	 *            not <code>null</code>
+	 * @param version
+	 *            not <code>null</code>
+	 * @param mediaType
+	 *            not <code>null</code>
+	 * @return {@link InputStream} needs to be closed
+	 */
+	InputStream readBinary(String id, String version, MediaType mediaType);
+
+	boolean exists(IdType resourceTypeIdVersion);
+
+	Bundle search(Class<? extends Resource> resourceType, Map<String, List<String>> parameters);
+
+	Bundle searchWithStrictHandling(Class<? extends Resource> resourceType, Map<String, List<String>> parameters);
+
+	CapabilityStatement getConformance();
+
+	StructureDefinition generateSnapshot(String url);
+
+	StructureDefinition generateSnapshot(StructureDefinition differential);
+}

--- a/dsf-fhir/dsf-fhir-webservice-client/src/main/java/org/highmed/fhir/client/FhirWebserviceClient.java
+++ b/dsf-fhir/dsf-fhir-webservice-client/src/main/java/org/highmed/fhir/client/FhirWebserviceClient.java
@@ -1,72 +1,10 @@
 package org.highmed.fhir.client;
 
-import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
-
-import javax.ws.rs.core.MediaType;
-
-import org.hl7.fhir.r4.model.Bundle;
-import org.hl7.fhir.r4.model.CapabilityStatement;
-import org.hl7.fhir.r4.model.IdType;
-import org.hl7.fhir.r4.model.Resource;
-import org.hl7.fhir.r4.model.StructureDefinition;
-
-public interface FhirWebserviceClient extends PreferReturnResource
+public interface FhirWebserviceClient extends BasicFhirWebserviceClient, RetryClient<BasicFhirWebserviceClient>
 {
 	String getBaseUrl();
 
-	PreferReturnMinimal withMinimalReturn();
+	PreferReturnOutcomeWithRetry withOperationOutcomeReturn();
 
-	PreferReturnOutcome withOperationOutcomeReturn();
-
-	void delete(Class<? extends Resource> resourceClass, String id);
-
-	void deleteConditionaly(Class<? extends Resource> resourceClass, Map<String, List<String>> criteria);
-
-	Resource read(String resourceTypeName, String id);
-
-	<R extends Resource> R read(Class<R> resourceType, String id);
-
-	<R extends Resource> boolean exists(Class<R> resourceType, String id);
-
-	InputStream readBinary(String id, MediaType mediaType);
-
-	/**
-	 * @param resourceTypeName
-	 *            not <code>null</code>
-	 * @param id
-	 *            not <code>null</code>
-	 * @param version
-	 *            not <code>null</code>
-	 * @return {@link InputStream} needs to be closed
-	 */
-	Resource read(String resourceTypeName, String id, String version);
-
-	<R extends Resource> R read(Class<R> resourceType, String id, String version);
-
-	<R extends Resource> boolean exists(Class<R> resourceType, String id, String version);
-
-	/**
-	 * @param id
-	 *            not <code>null</code>
-	 * @param version
-	 *            not <code>null</code>
-	 * @param mediaType
-	 *            not <code>null</code>
-	 * @return {@link InputStream} needs to be closed
-	 */
-	InputStream readBinary(String id, String version, MediaType mediaType);
-
-	boolean exists(IdType resourceTypeIdVersion);
-
-	Bundle search(Class<? extends Resource> resourceType, Map<String, List<String>> parameters);
-
-	Bundle searchWithStrictHandling(Class<? extends Resource> resourceType, Map<String, List<String>> parameters);
-
-	CapabilityStatement getConformance();
-
-	StructureDefinition generateSnapshot(String url);
-
-	StructureDefinition generateSnapshot(StructureDefinition differential);
+	PreferReturnMinimalWithRetry withMinimalReturn();
 }

--- a/dsf-fhir/dsf-fhir-webservice-client/src/main/java/org/highmed/fhir/client/PreferReturnMinimalRetryImpl.java
+++ b/dsf-fhir/dsf-fhir-webservice-client/src/main/java/org/highmed/fhir/client/PreferReturnMinimalRetryImpl.java
@@ -1,0 +1,66 @@
+package org.highmed.fhir.client;
+
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+
+import javax.ws.rs.core.MediaType;
+
+import org.highmed.dsf.fhir.prefer.PreferReturnType;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.IdType;
+import org.hl7.fhir.r4.model.Resource;
+
+class PreferReturnMinimalRetryImpl extends AbstractFhirWebserviceClientJerseyWithRetry implements PreferReturnMinimal
+{
+	PreferReturnMinimalRetryImpl(FhirWebserviceClientJersey delegate, int nTimes, long delayMillis)
+	{
+		super(delegate, nTimes, delayMillis);
+	}
+
+	@Override
+	public IdType create(Resource resource)
+	{
+		return retry(nTimes, delayMillis, () -> delegate.create(PreferReturnType.MINIMAL, resource).getId());
+	}
+
+	@Override
+	public IdType createConditionaly(Resource resource, String ifNoneExistCriteria)
+	{
+		return retry(nTimes, delayMillis,
+				() -> delegate.createConditionaly(PreferReturnType.MINIMAL, resource, ifNoneExistCriteria).getId());
+	}
+
+	@Override
+	public IdType createBinary(InputStream in, MediaType mediaType, String securityContextReference)
+	{
+		return retry(nTimes, delayMillis,
+				() -> delegate.createBinary(PreferReturnType.MINIMAL, in, mediaType, securityContextReference).getId());
+	}
+
+	@Override
+	public IdType update(Resource resource)
+	{
+		return retry(nTimes, delayMillis, () -> delegate.update(PreferReturnType.MINIMAL, resource).getId());
+	}
+
+	@Override
+	public IdType updateConditionaly(Resource resource, Map<String, List<String>> criteria)
+	{
+		return retry(nTimes, delayMillis,
+				() -> delegate.updateConditionaly(PreferReturnType.MINIMAL, resource, criteria).getId());
+	}
+
+	@Override
+	public IdType updateBinary(String id, InputStream in, MediaType mediaType, String securityContextReference)
+	{
+		return retry(nTimes, delayMillis, () -> delegate
+				.updateBinary(PreferReturnType.MINIMAL, id, in, mediaType, securityContextReference).getId());
+	}
+
+	@Override
+	public Bundle postBundle(Bundle bundle)
+	{
+		return retry(nTimes, delayMillis, () -> delegate.postBundle(PreferReturnType.MINIMAL, bundle));
+	}
+}

--- a/dsf-fhir/dsf-fhir-webservice-client/src/main/java/org/highmed/fhir/client/PreferReturnMinimalWithRetry.java
+++ b/dsf-fhir/dsf-fhir-webservice-client/src/main/java/org/highmed/fhir/client/PreferReturnMinimalWithRetry.java
@@ -1,0 +1,5 @@
+package org.highmed.fhir.client;
+
+public interface PreferReturnMinimalWithRetry extends PreferReturnMinimal, RetryClient<PreferReturnMinimal>
+{
+}

--- a/dsf-fhir/dsf-fhir-webservice-client/src/main/java/org/highmed/fhir/client/PreferReturnMinimalWithRetryImpl.java
+++ b/dsf-fhir/dsf-fhir-webservice-client/src/main/java/org/highmed/fhir/client/PreferReturnMinimalWithRetryImpl.java
@@ -1,0 +1,70 @@
+package org.highmed.fhir.client;
+
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+
+import javax.ws.rs.core.MediaType;
+
+import org.highmed.dsf.fhir.prefer.PreferReturnType;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.IdType;
+import org.hl7.fhir.r4.model.Resource;
+
+class PreferReturnMinimalWithRetryImpl implements PreferReturnMinimalWithRetry
+{
+	private final FhirWebserviceClientJersey delegate;
+
+	PreferReturnMinimalWithRetryImpl(FhirWebserviceClientJersey delegate)
+	{
+		this.delegate = delegate;
+	}
+
+	@Override
+	public IdType create(Resource resource)
+	{
+		return delegate.create(PreferReturnType.MINIMAL, resource).getId();
+	}
+
+	@Override
+	public IdType createConditionaly(Resource resource, String ifNoneExistCriteria)
+	{
+		return delegate.createConditionaly(PreferReturnType.MINIMAL, resource, ifNoneExistCriteria).getId();
+	}
+
+	@Override
+	public IdType createBinary(InputStream in, MediaType mediaType, String securityContextReference)
+	{
+		return delegate.createBinary(PreferReturnType.MINIMAL, in, mediaType, securityContextReference).getId();
+	}
+
+	@Override
+	public IdType update(Resource resource)
+	{
+		return delegate.update(PreferReturnType.MINIMAL, resource).getId();
+	}
+
+	@Override
+	public IdType updateConditionaly(Resource resource, Map<String, List<String>> criteria)
+	{
+		return delegate.updateConditionaly(PreferReturnType.MINIMAL, resource, criteria).getId();
+	}
+
+	@Override
+	public IdType updateBinary(String id, InputStream in, MediaType mediaType, String securityContextReference)
+	{
+		return delegate.updateBinary(PreferReturnType.MINIMAL, id, in, mediaType, securityContextReference).getId();
+	}
+
+	@Override
+	public Bundle postBundle(Bundle bundle)
+	{
+		return delegate.postBundle(PreferReturnType.MINIMAL, bundle);
+	}
+
+	@Override
+	public PreferReturnMinimal withRetry(int nTimes, long delayMillis)
+	{
+		return new PreferReturnMinimalRetryImpl(delegate, nTimes, delayMillis);
+	}
+}

--- a/dsf-fhir/dsf-fhir-webservice-client/src/main/java/org/highmed/fhir/client/PreferReturnOutcomeRetryImpl.java
+++ b/dsf-fhir/dsf-fhir-webservice-client/src/main/java/org/highmed/fhir/client/PreferReturnOutcomeRetryImpl.java
@@ -1,0 +1,73 @@
+package org.highmed.fhir.client;
+
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+
+import javax.ws.rs.core.MediaType;
+
+import org.highmed.dsf.fhir.prefer.PreferReturnType;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.OperationOutcome;
+import org.hl7.fhir.r4.model.Resource;
+
+class PreferReturnOutcomeRetryImpl extends AbstractFhirWebserviceClientJerseyWithRetry implements PreferReturnOutcome
+{
+	PreferReturnOutcomeRetryImpl(FhirWebserviceClientJersey delegate, int nTimes, long delayMillis)
+	{
+		super(delegate, nTimes, delayMillis);
+	}
+
+	@Override
+	public OperationOutcome create(Resource resource)
+	{
+		return retry(nTimes, delayMillis,
+				() -> delegate.create(PreferReturnType.OPERATION_OUTCOME, resource).getOperationOutcome());
+	}
+
+	@Override
+	public OperationOutcome createConditionaly(Resource resource, String ifNoneExistCriteria)
+	{
+		return retry(nTimes, delayMillis,
+				() -> delegate.createConditionaly(PreferReturnType.OPERATION_OUTCOME, resource, ifNoneExistCriteria)
+						.getOperationOutcome());
+	}
+
+	@Override
+	public OperationOutcome createBinary(InputStream in, MediaType mediaType, String securityContextReference)
+	{
+		return retry(nTimes, delayMillis,
+				() -> delegate.createBinary(PreferReturnType.OPERATION_OUTCOME, in, mediaType, securityContextReference)
+						.getOperationOutcome());
+	}
+
+	@Override
+	public OperationOutcome update(Resource resource)
+	{
+		return retry(nTimes, delayMillis,
+				() -> delegate.update(PreferReturnType.OPERATION_OUTCOME, resource).getOperationOutcome());
+	}
+
+	@Override
+	public OperationOutcome updateConditionaly(Resource resource, Map<String, List<String>> criteria)
+	{
+		return retry(nTimes, delayMillis, () -> delegate
+				.updateConditionaly(PreferReturnType.OPERATION_OUTCOME, resource, criteria).getOperationOutcome());
+	}
+
+	@Override
+	public OperationOutcome updateBinary(String id, InputStream in, MediaType mediaType,
+			String securityContextReference)
+	{
+		return retry(nTimes, delayMillis,
+				() -> delegate
+						.updateBinary(PreferReturnType.OPERATION_OUTCOME, id, in, mediaType, securityContextReference)
+						.getOperationOutcome());
+	}
+
+	@Override
+	public Bundle postBundle(Bundle bundle)
+	{
+		return retry(nTimes, delayMillis, () -> delegate.postBundle(PreferReturnType.OPERATION_OUTCOME, bundle));
+	}
+}

--- a/dsf-fhir/dsf-fhir-webservice-client/src/main/java/org/highmed/fhir/client/PreferReturnOutcomeWithRetry.java
+++ b/dsf-fhir/dsf-fhir-webservice-client/src/main/java/org/highmed/fhir/client/PreferReturnOutcomeWithRetry.java
@@ -1,0 +1,5 @@
+package org.highmed.fhir.client;
+
+public interface PreferReturnOutcomeWithRetry extends PreferReturnOutcome, RetryClient<PreferReturnOutcome>
+{
+}

--- a/dsf-fhir/dsf-fhir-webservice-client/src/main/java/org/highmed/fhir/client/PreferReturnOutcomeWithRetryImpl.java
+++ b/dsf-fhir/dsf-fhir-webservice-client/src/main/java/org/highmed/fhir/client/PreferReturnOutcomeWithRetryImpl.java
@@ -1,0 +1,75 @@
+package org.highmed.fhir.client;
+
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+
+import javax.ws.rs.core.MediaType;
+
+import org.highmed.dsf.fhir.prefer.PreferReturnType;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.OperationOutcome;
+import org.hl7.fhir.r4.model.Resource;
+
+class PreferReturnOutcomeWithRetryImpl implements PreferReturnOutcomeWithRetry
+{
+	private final FhirWebserviceClientJersey delegate;
+
+	PreferReturnOutcomeWithRetryImpl(FhirWebserviceClientJersey delegate)
+	{
+		this.delegate = delegate;
+	}
+
+	@Override
+	public OperationOutcome create(Resource resource)
+	{
+		return delegate.create(PreferReturnType.OPERATION_OUTCOME, resource).getOperationOutcome();
+	}
+
+	@Override
+	public OperationOutcome createConditionaly(Resource resource, String ifNoneExistCriteria)
+	{
+		return delegate.createConditionaly(PreferReturnType.OPERATION_OUTCOME, resource, ifNoneExistCriteria)
+				.getOperationOutcome();
+	}
+
+	@Override
+	public OperationOutcome createBinary(InputStream in, MediaType mediaType, String securityContextReference)
+	{
+		return delegate.createBinary(PreferReturnType.OPERATION_OUTCOME, in, mediaType, securityContextReference)
+				.getOperationOutcome();
+	}
+
+	@Override
+	public OperationOutcome update(Resource resource)
+	{
+		return delegate.update(PreferReturnType.OPERATION_OUTCOME, resource).getOperationOutcome();
+	}
+
+	@Override
+	public OperationOutcome updateConditionaly(Resource resource, Map<String, List<String>> criteria)
+	{
+		return delegate.updateConditionaly(PreferReturnType.OPERATION_OUTCOME, resource, criteria)
+				.getOperationOutcome();
+	}
+
+	@Override
+	public OperationOutcome updateBinary(String id, InputStream in, MediaType mediaType,
+			String securityContextReference)
+	{
+		return delegate.updateBinary(PreferReturnType.OPERATION_OUTCOME, id, in, mediaType, securityContextReference)
+				.getOperationOutcome();
+	}
+
+	@Override
+	public Bundle postBundle(Bundle bundle)
+	{
+		return delegate.postBundle(PreferReturnType.OPERATION_OUTCOME, bundle);
+	}
+
+	@Override
+	public PreferReturnOutcome withRetry(int nTimes, long delayMillis)
+	{
+		return new PreferReturnOutcomeRetryImpl(delegate, nTimes, delayMillis);
+	}
+}

--- a/dsf-fhir/dsf-fhir-webservice-client/src/main/java/org/highmed/fhir/client/RetryClient.java
+++ b/dsf-fhir/dsf-fhir-webservice-client/src/main/java/org/highmed/fhir/client/RetryClient.java
@@ -1,0 +1,58 @@
+package org.highmed.fhir.client;
+
+public interface RetryClient<T>
+{
+	int RETRY_ONCE = 1;
+	long FIVE_SECONDS = 5_000L;
+
+	/**
+	 * retries once after a delay of {@value RetryClient#FIVE_SECONDS} ms
+	 * 
+	 * @return T
+	 */
+	default T withRetry()
+	{
+		return withRetry(RETRY_ONCE, FIVE_SECONDS);
+	}
+
+	/**
+	 * retries <b>nTimes</b> and waits {@value RetryClient#FIVE_SECONDS} ms between tries
+	 * 
+	 * @param nTimes
+	 *            >= 0
+	 * @return T
+	 * 
+	 * @throws IllegalArgumentException
+	 *             if param <b>nTimes</b> is &lt; 0
+	 */
+	default T withRetry(int nTimes)
+	{
+		return withRetry(nTimes, FIVE_SECONDS);
+	}
+
+	/**
+	 * retries once after a delay of <b>delayMillis</b> ms
+	 * 
+	 * @param delayMillis
+	 *            >= 0
+	 * @return T
+	 * @throws IllegalArgumentException
+	 *             if param <b>delayMillis</b> is &lt; 0
+	 */
+	default T withRetry(long delayMillis)
+	{
+		return withRetry(RETRY_ONCE, delayMillis);
+	}
+
+	/**
+	 * @param nTimes
+	 *            >= 0
+	 * @param delayMillis
+	 *            >= 0
+	 * @return T
+	 * 
+	 * @throws IllegalArgumentException
+	 *             if param <b>nTimes</b> or <b>delayMillis</b> is &lt; 0
+	 */
+	T withRetry(int nTimes, long delayMillis);
+}


### PR DESCRIPTION
Adds retry on HTTP status 5xx or connect (e.g. denied) and connect timeout exceptions.

We might need to implement more or fix the existing retry cases in 
```java
AbstractFhirWebserviceClientJerseyWithRetry.shouldRetry(RuntimeException e)
```

The new retry functions are currently not used within existing code. I created issue #135 to track this.

closes #119 