### PR TITLE
Filters Rows in Case of IdatNotFoundException

### DIFF
--- a/dsf-bpe/dsf-bpe-process-feasibility/src/main/java/org/highmed/dsf/bpe/service/GenerateBloomFilters.java
+++ b/dsf-bpe/dsf-bpe-process-feasibility/src/main/java/org/highmed/dsf/bpe/service/GenerateBloomFilters.java
@@ -110,7 +110,7 @@ public class GenerateBloomFilters extends AbstractServiceDelegate
 		return new ResultSetTranslatorToTtpRbfOnlyImpl(ehrIdColumnPath,
 				createRecordBloomFilterGenerator(bloomFilterConfig.getPermutationSeed(),
 						bloomFilterConfig.getHmacSha2Key(), bloomFilterConfig.getHmacSha3Key()),
-				masterPatientIndexClient);
+				masterPatientIndexClient, ResultSetTranslatorToTtpRbfOnlyImpl.FILTER_ON_IDAT_NOT_FOUND_EXCEPTION);
 	}
 
 	protected RecordBloomFilterGenerator createRecordBloomFilterGenerator(long permutationSeed, Key hmacSha2Key,

--- a/dsf-pseudonymization/dsf-pseudonymization-medic/src/test/java/org/highmed/pseudonymization/translation/ResultSetTranslatorToTtpTest.java
+++ b/dsf-pseudonymization/dsf-pseudonymization-medic/src/test/java/org/highmed/pseudonymization/translation/ResultSetTranslatorToTtpTest.java
@@ -11,6 +11,7 @@ import java.util.Random;
 import javax.crypto.SecretKey;
 
 import org.highmed.mpi.client.Idat;
+import org.highmed.mpi.client.IdatNotFoundException;
 import org.highmed.mpi.client.MasterPatientIndexClient;
 import org.highmed.openehr.json.OpenEhrObjectMapperFactory;
 import org.highmed.openehr.model.structure.ResultSet;
@@ -52,9 +53,8 @@ public class ResultSetTranslatorToTtpTest
 				recordBloomFilterLength, permutationSeed, weights, lengths,
 				() -> new BloomFilterGenerator.HmacMd5HmacSha1BiGramHasher(hashKey1, hashKey2));
 
-		Map<String, Idat> idats = Map.of("ehrId1",
-				new IdatTestImpl("medicId1", "firstName1", "lastName1", "birthday1", "sex1", "street1", "zipCode1",
-						"city1", "country1", "insuranceNumber1"));
+		Map<String, Idat> idats = Map.of("ehrId1", new IdatTestImpl("medicId1", "firstName1", "lastName1", "birthday1",
+				"sex1", "street1", "zipCode1", "city1", "country1", "insuranceNumber1"));
 		MasterPatientIndexClient masterPatientIndexClient = new MasterPatientIndexClientTestImpl(idats);
 		String organizationIdentifier = "org1";
 		SecretKey organizationKey = AesGcmUtil.generateAES256Key();
@@ -62,8 +62,8 @@ public class ResultSetTranslatorToTtpTest
 		SecretKey researchStudyKey = AesGcmUtil.generateAES256Key();
 
 		ResultSetTranslatorToTtpImpl translator = new ResultSetTranslatorToTtpImpl(organizationIdentifier,
-				organizationKey, researchStudyIdentifier, researchStudyKey,
-				"/ehr_status/subject/external_ref/id/value", recordBloomFilterGenerator, masterPatientIndexClient);
+				organizationKey, researchStudyIdentifier, researchStudyKey, "/ehr_status/subject/external_ref/id/value",
+				recordBloomFilterGenerator, masterPatientIndexClient);
 
 		ObjectMapper openEhrObjectMapper = OpenEhrObjectMapperFactory.createObjectMapper();
 		ResultSet resultSet = openEhrObjectMapper
@@ -90,5 +90,105 @@ public class ResultSetTranslatorToTtpTest
 
 		logger.debug("Encoded ResultSet {}",
 				openEhrObjectMapper.writer(prettyPrinter).writeValueAsString(translatedResultSet));
+	}
+
+	@Test(expected = IdatNotFoundException.class)
+	public void testTranslateForTtpFailingMpiClientFails() throws Exception
+	{
+		Random random = new Random();
+
+		int recordBloomFilterLength = 2000;
+		long permutationSeed = 42L;
+
+		FieldWeights weights = new FieldWeights(0.1, 0.1, 0.1, 0.2, 0.05, 0.1, 0.05, 0.2, 0.1);
+		FieldBloomFilterLengths lengths = new FieldBloomFilterLengths(500, 500, 250, 50, 500, 250, 500, 500, 500);
+
+		byte[] hashKey1 = new byte[64];
+		random.nextBytes(hashKey1);
+		byte[] hashKey2 = new byte[64];
+		random.nextBytes(hashKey2);
+
+		RecordBloomFilterGenerator recordBloomFilterGenerator = new RecordBloomFilterGeneratorImpl(
+				recordBloomFilterLength, permutationSeed, weights, lengths,
+				() -> new BloomFilterGenerator.HmacMd5HmacSha1BiGramHasher(hashKey1, hashKey2));
+
+		MasterPatientIndexClient masterPatientIndexClient = id ->
+		{
+			throw new IdatNotFoundException(id);
+		};
+
+		String organizationIdentifier = "org1";
+		SecretKey organizationKey = AesGcmUtil.generateAES256Key();
+		String researchStudyIdentifier = "researchStudy1";
+		SecretKey researchStudyKey = AesGcmUtil.generateAES256Key();
+
+		ResultSetTranslatorToTtpImpl translator = new ResultSetTranslatorToTtpImpl(organizationIdentifier,
+				organizationKey, researchStudyIdentifier, researchStudyKey, "/ehr_status/subject/external_ref/id/value",
+				recordBloomFilterGenerator, masterPatientIndexClient);
+
+		ObjectMapper openEhrObjectMapper = OpenEhrObjectMapperFactory.createObjectMapper();
+		ResultSet resultSet = openEhrObjectMapper
+				.readValue(Files.readAllBytes(Paths.get("src/test/resources/result_5.json")), ResultSet.class);
+		assertNotNull(resultSet);
+		assertNotNull(resultSet.getColumns());
+		assertEquals(4, resultSet.getColumns().size());
+		assertNotNull(resultSet.getRows());
+		assertEquals(1, resultSet.getRows().size());
+		assertNotNull(resultSet.getRow(0));
+		assertEquals(4, resultSet.getRow(0).size());
+
+		translator.translate(resultSet);
+	}
+
+	@Test
+	public void testTranslateForTtpFailingMpiClientFilters() throws Exception
+	{
+		Random random = new Random();
+
+		int recordBloomFilterLength = 2000;
+		long permutationSeed = 42L;
+
+		FieldWeights weights = new FieldWeights(0.1, 0.1, 0.1, 0.2, 0.05, 0.1, 0.05, 0.2, 0.1);
+		FieldBloomFilterLengths lengths = new FieldBloomFilterLengths(500, 500, 250, 50, 500, 250, 500, 500, 500);
+
+		byte[] hashKey1 = new byte[64];
+		random.nextBytes(hashKey1);
+		byte[] hashKey2 = new byte[64];
+		random.nextBytes(hashKey2);
+
+		RecordBloomFilterGenerator recordBloomFilterGenerator = new RecordBloomFilterGeneratorImpl(
+				recordBloomFilterLength, permutationSeed, weights, lengths,
+				() -> new BloomFilterGenerator.HmacMd5HmacSha1BiGramHasher(hashKey1, hashKey2));
+
+		MasterPatientIndexClient masterPatientIndexClient = id ->
+		{
+			throw new IdatNotFoundException(id);
+		};
+
+		String organizationIdentifier = "org1";
+		SecretKey organizationKey = AesGcmUtil.generateAES256Key();
+		String researchStudyIdentifier = "researchStudy1";
+		SecretKey researchStudyKey = AesGcmUtil.generateAES256Key();
+
+		ResultSetTranslatorToTtpImpl translator = new ResultSetTranslatorToTtpImpl(organizationIdentifier,
+				organizationKey, researchStudyIdentifier, researchStudyKey, "/ehr_status/subject/external_ref/id/value",
+				recordBloomFilterGenerator, masterPatientIndexClient,
+				ResultSetTranslatorToTtpImpl.FILTER_ON_IDAT_NOT_FOUND_EXCEPTION);
+
+		ObjectMapper openEhrObjectMapper = OpenEhrObjectMapperFactory.createObjectMapper();
+		ResultSet resultSet = openEhrObjectMapper
+				.readValue(Files.readAllBytes(Paths.get("src/test/resources/result_5.json")), ResultSet.class);
+		assertNotNull(resultSet);
+		assertNotNull(resultSet.getColumns());
+		assertEquals(4, resultSet.getColumns().size());
+		assertNotNull(resultSet.getRows());
+		assertEquals(1, resultSet.getRows().size());
+		assertNotNull(resultSet.getRow(0));
+		assertEquals(4, resultSet.getRow(0).size());
+
+		ResultSet translate = translator.translate(resultSet);
+		assertNotNull(translate);
+		assertNotNull(translate.getRows());
+		assertEquals(0, translate.getRows().size());
 	}
 }

--- a/dsf-pseudonymization/dsf-pseudonymization-medic/src/test/java/org/highmed/pseudonymization/translation/ResultSetTranslatorToTtpTestRbfOnly.java
+++ b/dsf-pseudonymization/dsf-pseudonymization-medic/src/test/java/org/highmed/pseudonymization/translation/ResultSetTranslatorToTtpTestRbfOnly.java
@@ -11,6 +11,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.highmed.mpi.client.Idat;
+import org.highmed.mpi.client.IdatNotFoundException;
 import org.highmed.mpi.client.MasterPatientIndexClient;
 import org.highmed.openehr.json.OpenEhrObjectMapperFactory;
 import org.highmed.openehr.model.datatypes.StringRowElement;
@@ -62,8 +63,8 @@ public class ResultSetTranslatorToTtpTestRbfOnly
 
 		MasterPatientIndexClient masterPatientIndexClient = new MasterPatientIndexClientTestImpl(idats);
 
-		ResultSetTranslatorToTtpRbfOnlyImpl translator = new ResultSetTranslatorToTtpRbfOnlyImpl("/ehr_status/subject/external_ref/id/value", recordBloomFilterGenerator,
-				masterPatientIndexClient);
+		ResultSetTranslatorToTtpRbfOnlyImpl translator = new ResultSetTranslatorToTtpRbfOnlyImpl(
+				"/ehr_status/subject/external_ref/id/value", recordBloomFilterGenerator, masterPatientIndexClient);
 
 		ObjectMapper openEhrObjectMapper = OpenEhrObjectMapperFactory.createObjectMapper();
 		DefaultPrettyPrinter prettyPrinter = new DefaultPrettyPrinter();
@@ -72,7 +73,8 @@ public class ResultSetTranslatorToTtpTestRbfOnly
 		List<List<RowElement>> rows = IntStream.range(0, 15)
 				.mapToObj(id -> Collections.<RowElement> singletonList(new StringRowElement(String.valueOf(id))))
 				.collect(Collectors.toList());
-		ResultSet resultSet = new ResultSet(null, null, "SELECT e/ehr_status/subject/external_ref/id/value as EHRID FROM EHR e",
+		ResultSet resultSet = new ResultSet(null, null,
+				"SELECT e/ehr_status/subject/external_ref/id/value as EHRID FROM EHR e",
 				Collections.singleton(new Column("EHRID", "/ehr_status/subject/external_ref/id/value")), rows);
 
 		logger.debug("ResultSet {}", openEhrObjectMapper.writer(prettyPrinter).writeValueAsString(resultSet));
@@ -85,5 +87,85 @@ public class ResultSetTranslatorToTtpTestRbfOnly
 		assertNotNull(translated.getRows());
 		assertEquals(15, translated.getRows().size());
 		assertEquals(15, translated.getRows().stream().mapToInt(List::size).sum());
+	}
+
+	@Test(expected = IdatNotFoundException.class)
+	public void testIdsOnlyFailingMpiClientFails() throws Exception
+	{
+		Random random = new Random();
+
+		int recordBloomFilterLength = 2000;
+		long permutationSeed = 42L;
+
+		FieldWeights weights = new FieldWeights(0.1, 0.1, 0.1, 0.2, 0.05, 0.1, 0.05, 0.2, 0.1);
+		FieldBloomFilterLengths lengths = new FieldBloomFilterLengths(500, 500, 250, 50, 500, 250, 500, 500, 500);
+
+		byte[] hashKey1 = new byte[64];
+		random.nextBytes(hashKey1);
+		byte[] hashKey2 = new byte[64];
+		random.nextBytes(hashKey2);
+
+		RecordBloomFilterGenerator recordBloomFilterGenerator = new RecordBloomFilterGeneratorImpl(
+				recordBloomFilterLength, permutationSeed, weights, lengths,
+				() -> new BloomFilterGenerator.HmacMd5HmacSha1BiGramHasher(hashKey1, hashKey2));
+
+		MasterPatientIndexClient masterPatientIndexClient = id ->
+		{
+			throw new IdatNotFoundException(id);
+		};
+
+		ResultSetTranslatorToTtpRbfOnlyImpl translator = new ResultSetTranslatorToTtpRbfOnlyImpl(
+				"/ehr_status/subject/external_ref/id/value", recordBloomFilterGenerator, masterPatientIndexClient);
+
+		List<List<RowElement>> rows = IntStream.range(0, 15)
+				.mapToObj(id -> Collections.<RowElement> singletonList(new StringRowElement(String.valueOf(id))))
+				.collect(Collectors.toList());
+		ResultSet resultSet = new ResultSet(null, null,
+				"SELECT e/ehr_status/subject/external_ref/id/value as EHRID FROM EHR e",
+				Collections.singleton(new Column("EHRID", "/ehr_status/subject/external_ref/id/value")), rows);
+
+		translator.translate(resultSet);
+	}
+
+	@Test
+	public void testIdsOnlyFailingMpiClientFilters() throws Exception
+	{
+		Random random = new Random();
+
+		int recordBloomFilterLength = 2000;
+		long permutationSeed = 42L;
+
+		FieldWeights weights = new FieldWeights(0.1, 0.1, 0.1, 0.2, 0.05, 0.1, 0.05, 0.2, 0.1);
+		FieldBloomFilterLengths lengths = new FieldBloomFilterLengths(500, 500, 250, 50, 500, 250, 500, 500, 500);
+
+		byte[] hashKey1 = new byte[64];
+		random.nextBytes(hashKey1);
+		byte[] hashKey2 = new byte[64];
+		random.nextBytes(hashKey2);
+
+		RecordBloomFilterGenerator recordBloomFilterGenerator = new RecordBloomFilterGeneratorImpl(
+				recordBloomFilterLength, permutationSeed, weights, lengths,
+				() -> new BloomFilterGenerator.HmacMd5HmacSha1BiGramHasher(hashKey1, hashKey2));
+
+		MasterPatientIndexClient masterPatientIndexClient = id ->
+		{
+			throw new IdatNotFoundException(id);
+		};
+
+		ResultSetTranslatorToTtpRbfOnlyImpl translator = new ResultSetTranslatorToTtpRbfOnlyImpl(
+				"/ehr_status/subject/external_ref/id/value", recordBloomFilterGenerator, masterPatientIndexClient,
+				ResultSetTranslatorToTtpRbfOnlyImpl.FILTER_ON_IDAT_NOT_FOUND_EXCEPTION);
+
+		List<List<RowElement>> rows = IntStream.range(0, 15)
+				.mapToObj(id -> Collections.<RowElement> singletonList(new StringRowElement(String.valueOf(id))))
+				.collect(Collectors.toList());
+		ResultSet resultSet = new ResultSet(null, null,
+				"SELECT e/ehr_status/subject/external_ref/id/value as EHRID FROM EHR e",
+				Collections.singleton(new Column("EHRID", "/ehr_status/subject/external_ref/id/value")), rows);
+
+		ResultSet translate = translator.translate(resultSet);
+		assertNotNull(translate);
+		assertNotNull(translate.getRows());
+		assertEquals(0, translate.getRows().size());
 	}
 }


### PR DESCRIPTION
* Implements row filters for failing IDAT retrievals in ResultSetTranslatorToTtpImpl and ResultSetTranslatorToTtpRbfOnlyImpl.
* Uses new filter in GenerateBloomFilters.

fixes #146 