### PR TITLE
Fix Docker Test FHIR Server Base

### DIFF
--- a/dsf-tools/dsf-tools-test-data-generator/src/main/resources/config-templates/docker-test-fhir-config.properties
+++ b/dsf-tools/dsf-tools-test-data-generator/src/main/resources/config-templates/docker-test-fhir-config.properties
@@ -8,7 +8,7 @@ org.highmed.dsf.fhir.db.server_user=fhir_server_user
 org.highmed.dsf.fhir.db.server_user_password=xTZkzduUjYw3Bk7XQ4hYi2cRbunDAdNT
 
 org.highmed.dsf.fhir.organizationType=MeDIC
-org.highmed.dsf.fhir.serverBase=https://localhost/fhir
+org.highmed.dsf.fhir.serverBase=https://fhir/fhir
 org.highmed.dsf.fhir.defaultPageCount=20
 
 org.highmed.dsf.fhir.local-user.thumbprints=


### PR DESCRIPTION
The server base was set to https://localhost/fhir but the actual hostname of the FHIR server inside the Docker network is fhir and not localhost.

The server base is used to validate the fullUrl of transaction/batch bundles on update commands. In case one restarts the BPE, it tries to update resources like CodeSystem. For that update it uses https://fhir/fhir as base URL which doesn't match https://localhost/fhir.

Steps to reproduce:

1. Follow https://github.com/highmed/highmed-dsf/wiki/Build-and-Test-Project#manual-integration-testing-local-with-docker
2. stop the BPE and restart it