### PR TITLE
Issues/190 no rbf translators

### DIFF
--- a/dsf-bpe/dsf-bpe-process-base/src/main/java/org/highmed/dsf/bpe/ConstantsBase.java
+++ b/dsf-bpe/dsf-bpe-process-base/src/main/java/org/highmed/dsf/bpe/ConstantsBase.java
@@ -16,7 +16,8 @@ public interface ConstantsBase
 	String BPMN_EXECUTION_VARIABLE_LEADING_TASK = "leadingTask";
 	String BPMN_EXECUTION_VARIABLE_BUNDLE_ID = "bundleId";
 	String BPMN_EXECUTION_VARIABLE_QUERY_PARAMETERS = "queryParameters";
-	String BPMN_EXECUTION_VARIABLE_TTP_IDENTIFIER = "ttp";
+	String BPMN_EXECUTION_VARIABLE_TTP_IDENTIFIER = "ttpIdentifier";
+	String BPMN_EXECUTION_VARIABLE_LEADING_MEDIC_IDENTIFIER = "leadingMedicIdentifier";
 
 	/**
 	 * Used to distinguish if I am at the moment in a process called by another process by a CallActivity or not

--- a/dsf-bpe/dsf-bpe-server-jetty/conf/config.properties
+++ b/dsf-bpe/dsf-bpe-server-jetty/conf/config.properties
@@ -60,3 +60,8 @@ org.highmed.dsf.bpe.db.camunda_user_password=arpJ2FgJuYvUJhbxeuh7
 #org.highmed.dsf.bpe.process.excluded=
 #org.highmed.dsf.bpe.process.retired=
 #org.highmed.dsf.bpe.process_plugin_directroy=process
+
+#org.highmed.dsf.bpe.psn.organizationKey.keystore.file=psn/organization-keystore.jceks
+org.highmed.dsf.bpe.psn.organizationKey.keystore.password=password
+#org.highmed.dsf.bpe.psn.researchStudyKeys.keystore.file=psn/research-study-keystore.jceks
+org.highmed.dsf.bpe.psn.researchStudyKeys.keystore.password=password

--- a/dsf-bpe/dsf-bpe-server-jetty/conf/config.properties
+++ b/dsf-bpe/dsf-bpe-server-jetty/conf/config.properties
@@ -62,6 +62,6 @@ org.highmed.dsf.bpe.db.camunda_user_password=arpJ2FgJuYvUJhbxeuh7
 #org.highmed.dsf.bpe.process_plugin_directroy=process
 
 #org.highmed.dsf.bpe.psn.organizationKey.keystore.file=psn/organization-keystore.jceks
-org.highmed.dsf.bpe.psn.organizationKey.keystore.password=password
+#org.highmed.dsf.bpe.psn.organizationKey.keystore.password=password
 #org.highmed.dsf.bpe.psn.researchStudyKeys.keystore.file=psn/research-study-keystore.jceks
-org.highmed.dsf.bpe.psn.researchStudyKeys.keystore.password=password
+#org.highmed.dsf.bpe.psn.researchStudyKeys.keystore.password=password

--- a/dsf-bpe/dsf-bpe-server-jetty/docker/psn/README.md
+++ b/dsf-bpe/dsf-bpe-server-jetty/docker/psn/README.md
@@ -1,0 +1,1 @@
+empty directory for psn keystore's

--- a/dsf-docker-test-setup-3medic-ttp/medic1/bpe/.rsync-filter
+++ b/dsf-docker-test-setup-3medic-ttp/medic1/bpe/.rsync-filter
@@ -3,5 +3,5 @@
 - app/log/README.md
 - app/plugin/README.md
 - app/process/README.md
+- app/psn/README.md
 - proxy/ssl/README.md
-- app/psn/*

--- a/dsf-docker-test-setup-3medic-ttp/medic1/bpe/.rsync-filter
+++ b/dsf-docker-test-setup-3medic-ttp/medic1/bpe/.rsync-filter
@@ -4,3 +4,4 @@
 - app/plugin/README.md
 - app/process/README.md
 - proxy/ssl/README.md
+- app/psn/*

--- a/dsf-docker-test-setup-3medic-ttp/medic1/bpe/app/conf/config.properties
+++ b/dsf-docker-test-setup-3medic-ttp/medic1/bpe/app/conf/config.properties
@@ -62,6 +62,6 @@ org.highmed.dsf.bpe.process.excluded=computeFeasibility/0.4.0,computeDataSharing
 #org.highmed.dsf.bpe.process_plugin_directroy=process
 
 #org.highmed.dsf.bpe.psn.organizationKey.keystore.file=psn/organization-keystore.jceks
-org.highmed.dsf.bpe.psn.organizationKey.keystore.password=password
+#org.highmed.dsf.bpe.psn.organizationKey.keystore.password=password
 #org.highmed.dsf.bpe.psn.researchStudyKeys.keystore.file=psn/research-study-keystore.jceks
-org.highmed.dsf.bpe.psn.researchStudyKeys.keystore.password=password
+#org.highmed.dsf.bpe.psn.researchStudyKeys.keystore.password=password

--- a/dsf-docker-test-setup-3medic-ttp/medic1/bpe/app/conf/config.properties
+++ b/dsf-docker-test-setup-3medic-ttp/medic1/bpe/app/conf/config.properties
@@ -60,3 +60,8 @@ org.highmed.dsf.bpe.fhir.task.subscription.lastEventTimeFile=last_event/time.fil
 org.highmed.dsf.bpe.process.excluded=computeFeasibility/0.4.0,computeDataSharing/0.4.0,requestUpdateResources/0.4.0,updateAllowList/0.4.0
 #org.highmed.dsf.bpe.process.retired=
 #org.highmed.dsf.bpe.process_plugin_directroy=process
+
+#org.highmed.dsf.bpe.psn.organizationKey.keystore.file=psn/organization-keystore.jceks
+org.highmed.dsf.bpe.psn.organizationKey.keystore.password=password
+#org.highmed.dsf.bpe.psn.researchStudyKeys.keystore.file=psn/research-study-keystore.jceks
+org.highmed.dsf.bpe.psn.researchStudyKeys.keystore.password=password

--- a/dsf-docker-test-setup-3medic-ttp/medic1/bpe/app/psn/README.md
+++ b/dsf-docker-test-setup-3medic-ttp/medic1/bpe/app/psn/README.md
@@ -1,0 +1,1 @@
+empty directory for psn keystore's

--- a/dsf-docker-test-setup-3medic-ttp/medic1/bpe/docker-compose.yml
+++ b/dsf-docker-test-setup-3medic-ttp/medic1/bpe/docker-compose.yml
@@ -42,6 +42,9 @@ services:
       -  type: bind
          source: ./app/last_event
          target: /opt/bpe/last_event
+      -  type: bind
+         source: ./app/psn
+         target: /opt/bpe/psn
       environment:
          TZ: Europe/Berlin
       networks:

--- a/dsf-docker-test-setup-3medic-ttp/medic1/upload.yml
+++ b/dsf-docker-test-setup-3medic-ttp/medic1/upload.yml
@@ -16,6 +16,8 @@
          perms: no
          recursive: yes
          delete: yes
+         rsync_opts:
+            - "--exclude=app/psn/*"
    -  name: Synchronize fhir folder
       synchronize:
          src: fhir

--- a/dsf-docker-test-setup-3medic-ttp/medic1/upload.yml
+++ b/dsf-docker-test-setup-3medic-ttp/medic1/upload.yml
@@ -16,8 +16,6 @@
          perms: no
          recursive: yes
          delete: yes
-         rsync_opts:
-            - "--exclude=app/psn/*"
    -  name: Synchronize fhir folder
       synchronize:
          src: fhir

--- a/dsf-docker-test-setup-3medic-ttp/medic1/upload.yml
+++ b/dsf-docker-test-setup-3medic-ttp/medic1/upload.yml
@@ -37,6 +37,13 @@
          group: '2202'
          mode: '2775'
       become: true
+   -  name: Set bpe/app/psn permissions
+      file:
+         path: /opt/highmed/bpe/app/psn
+         owner: '{{ user }}'
+         group: '2202'
+         mode: '2775'
+      become: true
    -  name: Set fhir/app/log permissions
       file:
          path: /opt/highmed/fhir/app/log

--- a/dsf-docker-test-setup-3medic-ttp/medic2/bpe/.rsync-filter
+++ b/dsf-docker-test-setup-3medic-ttp/medic2/bpe/.rsync-filter
@@ -3,5 +3,5 @@
 - app/log/README.md
 - app/plugin/README.md
 - app/process/README.md
+- app/psn/README.md
 - proxy/ssl/README.md
-- app/psn/*

--- a/dsf-docker-test-setup-3medic-ttp/medic2/bpe/.rsync-filter
+++ b/dsf-docker-test-setup-3medic-ttp/medic2/bpe/.rsync-filter
@@ -4,3 +4,4 @@
 - app/plugin/README.md
 - app/process/README.md
 - proxy/ssl/README.md
+- app/psn/*

--- a/dsf-docker-test-setup-3medic-ttp/medic2/bpe/app/conf/config.properties
+++ b/dsf-docker-test-setup-3medic-ttp/medic2/bpe/app/conf/config.properties
@@ -62,6 +62,6 @@ org.highmed.dsf.bpe.process.excluded=computeFeasibility/0.4.0,computeDataSharing
 #org.highmed.dsf.bpe.process_plugin_directroy=process
 
 #org.highmed.dsf.bpe.psn.organizationKey.keystore.file=psn/organization-keystore.jceks
-org.highmed.dsf.bpe.psn.organizationKey.keystore.password=password
+#org.highmed.dsf.bpe.psn.organizationKey.keystore.password=password
 #org.highmed.dsf.bpe.psn.researchStudyKeys.keystore.file=psn/research-study-keystore.jceks
-org.highmed.dsf.bpe.psn.researchStudyKeys.keystore.password=password
+#org.highmed.dsf.bpe.psn.researchStudyKeys.keystore.password=password

--- a/dsf-docker-test-setup-3medic-ttp/medic2/bpe/app/conf/config.properties
+++ b/dsf-docker-test-setup-3medic-ttp/medic2/bpe/app/conf/config.properties
@@ -60,3 +60,8 @@ org.highmed.dsf.bpe.fhir.task.subscription.lastEventTimeFile=last_event/time.fil
 org.highmed.dsf.bpe.process.excluded=computeFeasibility/0.4.0,computeDataSharing/0.4.0,requestUpdateResources/0.4.0,updateAllowList/0.4.0
 #org.highmed.dsf.bpe.process.retired=
 #org.highmed.dsf.bpe.process_plugin_directroy=process
+
+#org.highmed.dsf.bpe.psn.organizationKey.keystore.file=psn/organization-keystore.jceks
+org.highmed.dsf.bpe.psn.organizationKey.keystore.password=password
+#org.highmed.dsf.bpe.psn.researchStudyKeys.keystore.file=psn/research-study-keystore.jceks
+org.highmed.dsf.bpe.psn.researchStudyKeys.keystore.password=password

--- a/dsf-docker-test-setup-3medic-ttp/medic2/bpe/app/psn/README.md
+++ b/dsf-docker-test-setup-3medic-ttp/medic2/bpe/app/psn/README.md
@@ -1,0 +1,1 @@
+empty directory for psn keystore's

--- a/dsf-docker-test-setup-3medic-ttp/medic2/bpe/docker-compose.yml
+++ b/dsf-docker-test-setup-3medic-ttp/medic2/bpe/docker-compose.yml
@@ -42,6 +42,9 @@ services:
       -  type: bind
          source: ./app/last_event
          target: /opt/bpe/last_event
+      -  type: bind
+         source: ./app/psn
+         target: /opt/bpe/psn
       environment:
          TZ: Europe/Berlin
       networks:

--- a/dsf-docker-test-setup-3medic-ttp/medic2/upload.yml
+++ b/dsf-docker-test-setup-3medic-ttp/medic2/upload.yml
@@ -16,6 +16,8 @@
          perms: no
          recursive: yes
          delete: yes
+         rsync_opts:
+            - "--exclude=app/psn/*"
    -  name: Synchronize fhir folder
       synchronize:
          src: fhir

--- a/dsf-docker-test-setup-3medic-ttp/medic2/upload.yml
+++ b/dsf-docker-test-setup-3medic-ttp/medic2/upload.yml
@@ -16,8 +16,6 @@
          perms: no
          recursive: yes
          delete: yes
-         rsync_opts:
-            - "--exclude=app/psn/*"
    -  name: Synchronize fhir folder
       synchronize:
          src: fhir

--- a/dsf-docker-test-setup-3medic-ttp/medic2/upload.yml
+++ b/dsf-docker-test-setup-3medic-ttp/medic2/upload.yml
@@ -37,6 +37,13 @@
          group: '2202'
          mode: '2775'
       become: true
+   -  name: Set bpe/app/psn permissions
+      file:
+         path: /opt/highmed/bpe/app/psn
+         owner: '{{ user }}'
+         group: '2202'
+         mode: '2775'
+      become: true
    -  name: Set fhir/app/log permissions
       file:
          path: /opt/highmed/fhir/app/log

--- a/dsf-docker-test-setup-3medic-ttp/medic3/bpe/.rsync-filter
+++ b/dsf-docker-test-setup-3medic-ttp/medic3/bpe/.rsync-filter
@@ -3,5 +3,5 @@
 - app/log/README.md
 - app/plugin/README.md
 - app/process/README.md
+- app/psn/README.md
 - proxy/ssl/README.md
-- app/psn/*

--- a/dsf-docker-test-setup-3medic-ttp/medic3/bpe/.rsync-filter
+++ b/dsf-docker-test-setup-3medic-ttp/medic3/bpe/.rsync-filter
@@ -4,3 +4,4 @@
 - app/plugin/README.md
 - app/process/README.md
 - proxy/ssl/README.md
+- app/psn/*

--- a/dsf-docker-test-setup-3medic-ttp/medic3/bpe/app/conf/config.properties
+++ b/dsf-docker-test-setup-3medic-ttp/medic3/bpe/app/conf/config.properties
@@ -62,6 +62,6 @@ org.highmed.dsf.bpe.process.excluded=computeFeasibility/0.4.0,computeDataSharing
 #org.highmed.dsf.bpe.process_plugin_directroy=process
 
 #org.highmed.dsf.bpe.psn.organizationKey.keystore.file=psn/organization-keystore.jceks
-org.highmed.dsf.bpe.psn.organizationKey.keystore.password=password
+#org.highmed.dsf.bpe.psn.organizationKey.keystore.password=password
 #org.highmed.dsf.bpe.psn.researchStudyKeys.keystore.file=psn/research-study-keystore.jceks
-org.highmed.dsf.bpe.psn.researchStudyKeys.keystore.password=password
+#org.highmed.dsf.bpe.psn.researchStudyKeys.keystore.password=password

--- a/dsf-docker-test-setup-3medic-ttp/medic3/bpe/app/conf/config.properties
+++ b/dsf-docker-test-setup-3medic-ttp/medic3/bpe/app/conf/config.properties
@@ -60,3 +60,8 @@ org.highmed.dsf.bpe.fhir.task.subscription.lastEventTimeFile=last_event/time.fil
 org.highmed.dsf.bpe.process.excluded=computeFeasibility/0.4.0,computeDataSharing/0.4.0,requestUpdateResources/0.4.0,updateAllowList/0.4.0
 #org.highmed.dsf.bpe.process.retired=
 #org.highmed.dsf.bpe.process_plugin_directroy=process
+
+#org.highmed.dsf.bpe.psn.organizationKey.keystore.file=psn/organization-keystore.jceks
+org.highmed.dsf.bpe.psn.organizationKey.keystore.password=password
+#org.highmed.dsf.bpe.psn.researchStudyKeys.keystore.file=psn/research-study-keystore.jceks
+org.highmed.dsf.bpe.psn.researchStudyKeys.keystore.password=password

--- a/dsf-docker-test-setup-3medic-ttp/medic3/bpe/app/psn/README.md
+++ b/dsf-docker-test-setup-3medic-ttp/medic3/bpe/app/psn/README.md
@@ -1,0 +1,1 @@
+empty directory for psn keystore's

--- a/dsf-docker-test-setup-3medic-ttp/medic3/bpe/docker-compose.yml
+++ b/dsf-docker-test-setup-3medic-ttp/medic3/bpe/docker-compose.yml
@@ -42,6 +42,9 @@ services:
       -  type: bind
          source: ./app/last_event
          target: /opt/bpe/last_event
+      -  type: bind
+         source: ./app/psn
+         target: /opt/bpe/psn
       environment:
          TZ: Europe/Berlin
       networks:

--- a/dsf-docker-test-setup-3medic-ttp/medic3/upload.yml
+++ b/dsf-docker-test-setup-3medic-ttp/medic3/upload.yml
@@ -16,6 +16,8 @@
          perms: no
          recursive: yes
          delete: yes
+         rsync_opts:
+            - "--exclude=app/psn/*"
    -  name: Synchronize fhir folder
       synchronize:
          src: fhir

--- a/dsf-docker-test-setup-3medic-ttp/medic3/upload.yml
+++ b/dsf-docker-test-setup-3medic-ttp/medic3/upload.yml
@@ -16,8 +16,6 @@
          perms: no
          recursive: yes
          delete: yes
-         rsync_opts:
-            - "--exclude=app/psn/*"
    -  name: Synchronize fhir folder
       synchronize:
          src: fhir

--- a/dsf-docker-test-setup-3medic-ttp/medic3/upload.yml
+++ b/dsf-docker-test-setup-3medic-ttp/medic3/upload.yml
@@ -37,6 +37,13 @@
          group: '2202'
          mode: '2775'
       become: true
+   -  name: Set bpe/app/psn permissions
+      file:
+        path: /opt/highmed/bpe/app/psn
+        owner: '{{ user }}'
+        group: '2202'
+        mode: '2775'
+      become: true
    -  name: Set fhir/app/log permissions
       file:
          path: /opt/highmed/fhir/app/log

--- a/dsf-docker-test-setup-3medic-ttp/ttp/bpe/.rsync-filter
+++ b/dsf-docker-test-setup-3medic-ttp/ttp/bpe/.rsync-filter
@@ -3,5 +3,5 @@
 - app/log/README.md
 - app/plugin/README.md
 - app/process/README.md
+- app/psn/README.md
 - proxy/ssl/README.md
-- app/psn/*

--- a/dsf-docker-test-setup-3medic-ttp/ttp/bpe/.rsync-filter
+++ b/dsf-docker-test-setup-3medic-ttp/ttp/bpe/.rsync-filter
@@ -4,3 +4,4 @@
 - app/plugin/README.md
 - app/process/README.md
 - proxy/ssl/README.md
+- app/psn/*

--- a/dsf-docker-test-setup-3medic-ttp/ttp/bpe/app/conf/config.properties
+++ b/dsf-docker-test-setup-3medic-ttp/ttp/bpe/app/conf/config.properties
@@ -60,3 +60,8 @@ org.highmed.dsf.bpe.fhir.task.subscription.lastEventTimeFile=last_event/time.fil
 org.highmed.dsf.bpe.process.excluded=localServicesIntegration/0.4.0,requestFeasibility/0.4.0,executeFeasibility/0.4.0,requestDataSharing/0.4.0,executeDataSharing/0.4.0
 #org.highmed.dsf.bpe.process.retired=
 #org.highmed.dsf.bpe.process_plugin_directroy=process
+
+#org.highmed.dsf.bpe.psn.organizationKey.keystore.file=psn/organization-keystore.jceks
+org.highmed.dsf.bpe.psn.organizationKey.keystore.password=password
+#org.highmed.dsf.bpe.psn.researchStudyKeys.keystore.file=psn/research-study-keystore.jceks
+org.highmed.dsf.bpe.psn.researchStudyKeys.keystore.password=password

--- a/dsf-docker-test-setup-3medic-ttp/ttp/bpe/app/conf/config.properties
+++ b/dsf-docker-test-setup-3medic-ttp/ttp/bpe/app/conf/config.properties
@@ -62,6 +62,6 @@ org.highmed.dsf.bpe.process.excluded=localServicesIntegration/0.4.0,requestFeasi
 #org.highmed.dsf.bpe.process_plugin_directroy=process
 
 #org.highmed.dsf.bpe.psn.organizationKey.keystore.file=psn/organization-keystore.jceks
-org.highmed.dsf.bpe.psn.organizationKey.keystore.password=password
+#org.highmed.dsf.bpe.psn.organizationKey.keystore.password=password
 #org.highmed.dsf.bpe.psn.researchStudyKeys.keystore.file=psn/research-study-keystore.jceks
-org.highmed.dsf.bpe.psn.researchStudyKeys.keystore.password=password
+#org.highmed.dsf.bpe.psn.researchStudyKeys.keystore.password=password

--- a/dsf-docker-test-setup-3medic-ttp/ttp/bpe/app/psn/README.md
+++ b/dsf-docker-test-setup-3medic-ttp/ttp/bpe/app/psn/README.md
@@ -1,0 +1,1 @@
+empty directory for psn keystore's

--- a/dsf-docker-test-setup-3medic-ttp/ttp/bpe/docker-compose.yml
+++ b/dsf-docker-test-setup-3medic-ttp/ttp/bpe/docker-compose.yml
@@ -42,6 +42,9 @@ services:
       -  type: bind
          source: ./app/last_event
          target: /opt/bpe/last_event
+      -  type: bind
+         source: ./app/psn
+         target: /opt/bpe/psn
       environment:
          TZ: Europe/Berlin
       networks:

--- a/dsf-docker-test-setup-3medic-ttp/ttp/upload.yml
+++ b/dsf-docker-test-setup-3medic-ttp/ttp/upload.yml
@@ -16,6 +16,8 @@
          perms: no
          recursive: yes
          delete: yes
+         rsync_opts:
+            - "--exclude=app/psn/*"
    -  name: Synchronize fhir folder
       synchronize:
          src: fhir

--- a/dsf-docker-test-setup-3medic-ttp/ttp/upload.yml
+++ b/dsf-docker-test-setup-3medic-ttp/ttp/upload.yml
@@ -16,8 +16,6 @@
          perms: no
          recursive: yes
          delete: yes
-         rsync_opts:
-            - "--exclude=app/psn/*"
    -  name: Synchronize fhir folder
       synchronize:
          src: fhir

--- a/dsf-docker-test-setup-3medic-ttp/ttp/upload.yml
+++ b/dsf-docker-test-setup-3medic-ttp/ttp/upload.yml
@@ -37,6 +37,13 @@
          group: '2202'
          mode: '2775'
       become: true
+   -  name: Set bpe/app/psn permissions
+      file:
+         path: /opt/highmed/bpe/app/psn
+         owner: '{{ user }}'
+         group: '2202'
+         mode: '2775'
+      become: true
    -  name: Set fhir/app/log permissions
       file:
          path: /opt/highmed/fhir/app/log

--- a/dsf-docker-test-setup/bpe/app/conf/config.properties
+++ b/dsf-docker-test-setup/bpe/app/conf/config.properties
@@ -60,3 +60,8 @@ org.highmed.dsf.bpe.fhir.task.subscription.lastEventTimeFile=last_event/time.fil
 #org.highmed.dsf.bpe.process.excluded=
 #org.highmed.dsf.bpe.process.retired=
 #org.highmed.dsf.bpe.process_plugin_directroy=process
+
+#org.highmed.dsf.bpe.psn.organizationKey.keystore.file=psn/organization-keystore.jceks
+org.highmed.dsf.bpe.psn.organizationKey.keystore.password=password
+#org.highmed.dsf.bpe.psn.researchStudyKeys.keystore.file=psn/research-study-keystore.jceks
+org.highmed.dsf.bpe.psn.researchStudyKeys.keystore.password=password

--- a/dsf-docker-test-setup/bpe/app/conf/config.properties
+++ b/dsf-docker-test-setup/bpe/app/conf/config.properties
@@ -62,6 +62,6 @@ org.highmed.dsf.bpe.fhir.task.subscription.lastEventTimeFile=last_event/time.fil
 #org.highmed.dsf.bpe.process_plugin_directroy=process
 
 #org.highmed.dsf.bpe.psn.organizationKey.keystore.file=psn/organization-keystore.jceks
-org.highmed.dsf.bpe.psn.organizationKey.keystore.password=password
+#org.highmed.dsf.bpe.psn.organizationKey.keystore.password=password
 #org.highmed.dsf.bpe.psn.researchStudyKeys.keystore.file=psn/research-study-keystore.jceks
-org.highmed.dsf.bpe.psn.researchStudyKeys.keystore.password=password
+#org.highmed.dsf.bpe.psn.researchStudyKeys.keystore.password=password

--- a/dsf-docker-test-setup/bpe/app/psn/README.md
+++ b/dsf-docker-test-setup/bpe/app/psn/README.md
@@ -1,0 +1,1 @@
+empty directory for psn keystore's

--- a/dsf-docker-test-setup/bpe/docker-compose.yml
+++ b/dsf-docker-test-setup/bpe/docker-compose.yml
@@ -44,6 +44,9 @@ services:
       -  type: bind
          source: ./app/last_event
          target: /opt/bpe/last_event
+      -  type: bind
+         source: ./app/psn
+         target: /opt/bpe/psn
       environment:
          TZ: Europe/Berlin
 # Use EXTRA_JVM_ARGS to specify special jvm parameters, e.g. jmx connection config below

--- a/dsf-pseudonymization/dsf-pseudonymization-base/src/main/java/org/highmed/pseudonymization/crypto/AesGcmUtil.java
+++ b/dsf-pseudonymization/dsf-pseudonymization-base/src/main/java/org/highmed/pseudonymization/crypto/AesGcmUtil.java
@@ -17,7 +17,7 @@ import javax.crypto.spec.SecretKeySpec;
 
 public class AesGcmUtil
 {
-	public static final String AES = "AES";
+	private static final String AES = "AES";
 	private static final String AES_MODE_PADDING = "AES/GCM/NoPadding";
 	private static final int AES_KEY_SIZE = 256;
 	private static final int GCM_IV_LENGTH = 12;

--- a/dsf-pseudonymization/dsf-pseudonymization-base/src/main/java/org/highmed/pseudonymization/crypto/AesGcmUtil.java
+++ b/dsf-pseudonymization/dsf-pseudonymization-base/src/main/java/org/highmed/pseudonymization/crypto/AesGcmUtil.java
@@ -17,7 +17,7 @@ import javax.crypto.spec.SecretKeySpec;
 
 public class AesGcmUtil
 {
-	private static final String AES = "AES";
+	public static final String AES = "AES";
 	private static final String AES_MODE_PADDING = "AES/GCM/NoPadding";
 	private static final int AES_KEY_SIZE = 256;
 	private static final int GCM_IV_LENGTH = 12;

--- a/dsf-pseudonymization/dsf-pseudonymization-medic/src/main/java/org/highmed/pseudonymization/translation/ResultSetTranslatorToTtpNoRbf.java
+++ b/dsf-pseudonymization/dsf-pseudonymization-medic/src/main/java/org/highmed/pseudonymization/translation/ResultSetTranslatorToTtpNoRbf.java
@@ -1,0 +1,5 @@
+package org.highmed.pseudonymization.translation;
+
+public interface ResultSetTranslatorToTtpNoRbf extends ResultSetTranslatorToTtp
+{
+}

--- a/dsf-pseudonymization/dsf-pseudonymization-medic/src/main/java/org/highmed/pseudonymization/translation/ResultSetTranslatorToTtpNoRbfImpl.java
+++ b/dsf-pseudonymization/dsf-pseudonymization-medic/src/main/java/org/highmed/pseudonymization/translation/ResultSetTranslatorToTtpNoRbfImpl.java
@@ -1,0 +1,109 @@
+package org.highmed.pseudonymization.translation;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.crypto.SecretKey;
+
+import org.highmed.openehr.model.datatypes.StringRowElement;
+import org.highmed.openehr.model.structure.Column;
+import org.highmed.openehr.model.structure.Meta;
+import org.highmed.openehr.model.structure.ResultSet;
+import org.highmed.openehr.model.structure.RowElement;
+import org.highmed.pseudonymization.openehr.Constants;
+
+public class ResultSetTranslatorToTtpNoRbfImpl extends AbstractResultSetTranslator
+		implements ResultSetTranslatorToTtpNoRbf
+{
+	private final String organizationIdentifier;
+	private final SecretKey organizationKey;
+	private final String researchStudyIdentifier;
+	private final SecretKey researchStudyKey;
+	private final String ehrIdColumnPath;
+
+	public ResultSetTranslatorToTtpNoRbfImpl(String organizationIdentifier, SecretKey organizationKey,
+			String researchStudyIdentifier, SecretKey researchStudyKey, String ehrIdColumnPath)
+	{
+		this.organizationIdentifier = Objects.requireNonNull(organizationIdentifier, "organizationIdentifier");
+		this.organizationKey = Objects.requireNonNull(organizationKey, "organizationKey");
+		this.researchStudyIdentifier = Objects.requireNonNull(researchStudyIdentifier, "researchStudyIdentifier");
+		this.researchStudyKey = Objects.requireNonNull(researchStudyKey, "researchStudyKey");
+		this.ehrIdColumnPath = Objects.requireNonNull(ehrIdColumnPath, "ehrIdColumnPath");
+	}
+
+	@Override
+	public ResultSet translate(ResultSet resultSet)
+	{
+		int ehrIdColumnIndex = getEhrColumnIndex(resultSet.getColumns());
+
+		if (ehrIdColumnIndex < 0)
+			throw new IllegalArgumentException("Missing ehr id column with name '" + Constants.EHRID_COLUMN_NAME
+					+ "' and path '" + ehrIdColumnPath + "'");
+
+		Meta meta = copyMeta(resultSet.getMeta());
+		List<Column> columns = encodeColumnsWithEhrId(resultSet.getColumns());
+		List<List<RowElement>> rows = encodeRowsWithEhrId(ehrIdColumnIndex, resultSet.getRows());
+
+		return new ResultSet(meta, resultSet.getName(), resultSet.getQuery(), columns, rows);
+	}
+
+	private int getEhrColumnIndex(List<Column> columns)
+	{
+		for (int i = 0; i < columns.size(); i++)
+			if (isEhrIdColumn().test(columns.get(i)))
+				return i;
+
+		return -1;
+	}
+
+	private Predicate<? super Column> isEhrIdColumn()
+	{
+		return column -> Constants.EHRID_COLUMN_NAME.equals(column.getName())
+				&& ehrIdColumnPath.equals(column.getPath());
+	}
+
+	private List<Column> encodeColumnsWithEhrId(List<Column> columns)
+	{
+		Stream<Column> s1 = columns.stream().filter(isEhrIdColumn().negate()).map(copyColumn());
+		Stream<Column> s2 = newMedicIdColumn();
+		return Stream.concat(s1, s2).collect(Collectors.toList());
+	}
+
+	private Stream<Column> newMedicIdColumn()
+	{
+		return Stream.of(new Column(Constants.MEDICID_COLUMN_NAME, Constants.MEDICID_COLUMN_PATH));
+	}
+
+	private List<List<RowElement>> encodeRowsWithEhrId(int ehrIdColumnIndex, List<List<RowElement>> rows)
+	{
+		return rows.parallelStream().map(encodeRowWithEhrId(ehrIdColumnIndex)).filter(e -> e != null)
+				.collect(Collectors.toList());
+	}
+
+	private Function<List<RowElement>, List<RowElement>> encodeRowWithEhrId(int ehrIdColumnIndex)
+	{
+		return rowElements ->
+		{
+			List<RowElement> newRowElements = new ArrayList<>();
+			for (int i = 0; i < rowElements.size(); i++)
+				if (i != ehrIdColumnIndex)
+					newRowElements.add(
+							toEncryptedMdatRowElement(rowElements.get(i), researchStudyKey, researchStudyIdentifier));
+
+			RowElement ehrId = rowElements.get(ehrIdColumnIndex);
+			newRowElements.add(encodeAsEncrypedMedicId(ehrId));
+
+			return newRowElements;
+		};
+	}
+
+	private RowElement encodeAsEncrypedMedicId(RowElement ehrId)
+	{
+		return new StringRowElement(encrypt(organizationKey, organizationIdentifier, ehrId.getValueAsString()));
+	}
+}

--- a/dsf-pseudonymization/dsf-pseudonymization-medic/src/main/java/org/highmed/pseudonymization/translation/ResultSetTranslatorToTtpRbfOnly.java
+++ b/dsf-pseudonymization/dsf-pseudonymization-medic/src/main/java/org/highmed/pseudonymization/translation/ResultSetTranslatorToTtpRbfOnly.java
@@ -1,5 +1,5 @@
 package org.highmed.pseudonymization.translation;
 
-public interface ResultSetTranslatorToTtpRbfOnly extends ResultSetTranslator
+public interface ResultSetTranslatorToTtpRbfOnly extends ResultSetTranslatorToTtp
 {
 }

--- a/dsf-pseudonymization/dsf-pseudonymization-medic/src/main/java/org/highmed/pseudonymization/translation/ResultSetTranslatorToTtpWithRbf.java
+++ b/dsf-pseudonymization/dsf-pseudonymization-medic/src/main/java/org/highmed/pseudonymization/translation/ResultSetTranslatorToTtpWithRbf.java
@@ -1,0 +1,5 @@
+package org.highmed.pseudonymization.translation;
+
+public interface ResultSetTranslatorToTtpWithRbf extends ResultSetTranslatorToTtp
+{
+}

--- a/dsf-pseudonymization/dsf-pseudonymization-medic/src/main/java/org/highmed/pseudonymization/translation/ResultSetTranslatorToTtpWithRbfImpl.java
+++ b/dsf-pseudonymization/dsf-pseudonymization-medic/src/main/java/org/highmed/pseudonymization/translation/ResultSetTranslatorToTtpWithRbfImpl.java
@@ -26,9 +26,10 @@ import org.highmed.pseudonymization.openehr.Constants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ResultSetTranslatorToTtpImpl extends AbstractResultSetTranslator implements ResultSetTranslatorToTtp
+public class ResultSetTranslatorToTtpWithRbfImpl extends AbstractResultSetTranslator
+		implements ResultSetTranslatorToTtpWithRbf
 {
-	private static final Logger logger = LoggerFactory.getLogger(ResultSetTranslatorToTtpImpl.class);
+	private static final Logger logger = LoggerFactory.getLogger(ResultSetTranslatorToTtpWithRbfImpl.class);
 
 	public static final Function<Supplier<Idat>, Idat> FILTER_ON_IDAT_NOT_FOUND_EXCEPTION = supplier ->
 	{
@@ -67,7 +68,7 @@ public class ResultSetTranslatorToTtpImpl extends AbstractResultSetTranslator im
 
 	private final Function<Supplier<Idat>, Idat> retrieveIdatErrorHandler;
 
-	public ResultSetTranslatorToTtpImpl(String organizationIdentifier, SecretKey organizationKey,
+	public ResultSetTranslatorToTtpWithRbfImpl(String organizationIdentifier, SecretKey organizationKey,
 			String researchStudyIdentifier, SecretKey researchStudyKey, String ehrIdColumnPath,
 			RecordBloomFilterGenerator recordBloomFilterGenerator, MasterPatientIndexClient masterPatientIndexClient)
 	{
@@ -75,7 +76,7 @@ public class ResultSetTranslatorToTtpImpl extends AbstractResultSetTranslator im
 				recordBloomFilterGenerator, masterPatientIndexClient, THROW_ON_IDAT_NOT_FOUND_EXCEPTION);
 	}
 
-	public ResultSetTranslatorToTtpImpl(String organizationIdentifier, SecretKey organizationKey,
+	public ResultSetTranslatorToTtpWithRbfImpl(String organizationIdentifier, SecretKey organizationKey,
 			String researchStudyIdentifier, SecretKey researchStudyKey, String ehrIdColumnPath,
 			RecordBloomFilterGenerator recordBloomFilterGenerator, MasterPatientIndexClient masterPatientIndexClient,
 			Function<Supplier<Idat>, Idat> retrieveIdatErrorHandler)

--- a/dsf-pseudonymization/dsf-pseudonymization-medic/src/test/java/org/highmed/pseudonymization/translation/ResultSetTranslatorToTtpNoRbfTest.java
+++ b/dsf-pseudonymization/dsf-pseudonymization-medic/src/test/java/org/highmed/pseudonymization/translation/ResultSetTranslatorToTtpNoRbfTest.java
@@ -1,0 +1,74 @@
+package org.highmed.pseudonymization.translation;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.Random;
+
+import javax.crypto.SecretKey;
+
+import org.highmed.mpi.client.Idat;
+import org.highmed.mpi.client.IdatNotFoundException;
+import org.highmed.mpi.client.MasterPatientIndexClient;
+import org.highmed.openehr.json.OpenEhrObjectMapperFactory;
+import org.highmed.openehr.model.structure.ResultSet;
+import org.highmed.pseudonymization.bloomfilter.BloomFilterGenerator;
+import org.highmed.pseudonymization.bloomfilter.RecordBloomFilterGenerator;
+import org.highmed.pseudonymization.bloomfilter.RecordBloomFilterGeneratorImpl;
+import org.highmed.pseudonymization.bloomfilter.RecordBloomFilterGeneratorImpl.FieldBloomFilterLengths;
+import org.highmed.pseudonymization.bloomfilter.RecordBloomFilterGeneratorImpl.FieldWeights;
+import org.highmed.pseudonymization.crypto.AesGcmUtil;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.core.util.DefaultIndenter;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class ResultSetTranslatorToTtpNoRbfTest
+{
+	private static final Logger logger = LoggerFactory.getLogger(ResultSetTranslatorToTtpNoRbfTest.class);
+
+	@Test
+	public void testTranslateForTtp() throws Exception
+	{
+		String organizationIdentifier = "org1";
+		SecretKey organizationKey = AesGcmUtil.generateAES256Key();
+		String researchStudyIdentifier = "researchStudy1";
+		SecretKey researchStudyKey = AesGcmUtil.generateAES256Key();
+
+		ResultSetTranslatorToTtpNoRbfImpl translator = new ResultSetTranslatorToTtpNoRbfImpl(organizationIdentifier,
+				organizationKey, researchStudyIdentifier, researchStudyKey,
+				"/ehr_status/subject/external_ref/id/value");
+
+		ObjectMapper openEhrObjectMapper = OpenEhrObjectMapperFactory.createObjectMapper();
+		ResultSet resultSet = openEhrObjectMapper
+				.readValue(Files.readAllBytes(Paths.get("src/test/resources/result_5.json")), ResultSet.class);
+		assertNotNull(resultSet);
+		assertNotNull(resultSet.getColumns());
+		assertEquals(4, resultSet.getColumns().size());
+		assertNotNull(resultSet.getRows());
+		assertEquals(1, resultSet.getRows().size());
+		assertNotNull(resultSet.getRow(0));
+		assertEquals(4, resultSet.getRow(0).size());
+
+		ResultSet translatedResultSet = translator.translate(resultSet);
+		assertNotNull(translatedResultSet);
+		assertNotNull(translatedResultSet.getColumns());
+		assertEquals(4, translatedResultSet.getColumns().size());
+		assertNotNull(translatedResultSet.getRows());
+		assertEquals(1, translatedResultSet.getRows().size());
+		assertNotNull(translatedResultSet.getRow(0));
+		assertEquals(4, translatedResultSet.getRow(0).size());
+
+		DefaultPrettyPrinter prettyPrinter = new DefaultPrettyPrinter();
+		prettyPrinter.indentArraysWith(DefaultIndenter.SYSTEM_LINEFEED_INSTANCE);
+
+		logger.debug("Encoded ResultSet {}",
+				openEhrObjectMapper.writer(prettyPrinter).writeValueAsString(translatedResultSet));
+	}
+}

--- a/dsf-pseudonymization/dsf-pseudonymization-medic/src/test/java/org/highmed/pseudonymization/translation/ResultSetTranslatorToTtpNoRbfTest.java
+++ b/dsf-pseudonymization/dsf-pseudonymization-medic/src/test/java/org/highmed/pseudonymization/translation/ResultSetTranslatorToTtpNoRbfTest.java
@@ -5,21 +5,11 @@ import static org.junit.Assert.assertNotNull;
 
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.Map;
-import java.util.Random;
 
 import javax.crypto.SecretKey;
 
-import org.highmed.mpi.client.Idat;
-import org.highmed.mpi.client.IdatNotFoundException;
-import org.highmed.mpi.client.MasterPatientIndexClient;
 import org.highmed.openehr.json.OpenEhrObjectMapperFactory;
 import org.highmed.openehr.model.structure.ResultSet;
-import org.highmed.pseudonymization.bloomfilter.BloomFilterGenerator;
-import org.highmed.pseudonymization.bloomfilter.RecordBloomFilterGenerator;
-import org.highmed.pseudonymization.bloomfilter.RecordBloomFilterGeneratorImpl;
-import org.highmed.pseudonymization.bloomfilter.RecordBloomFilterGeneratorImpl.FieldBloomFilterLengths;
-import org.highmed.pseudonymization.bloomfilter.RecordBloomFilterGeneratorImpl.FieldWeights;
 import org.highmed.pseudonymization.crypto.AesGcmUtil;
 import org.junit.Test;
 import org.slf4j.Logger;

--- a/dsf-pseudonymization/dsf-pseudonymization-medic/src/test/java/org/highmed/pseudonymization/translation/ResultSetTranslatorToTtpWithRbfTest.java
+++ b/dsf-pseudonymization/dsf-pseudonymization-medic/src/test/java/org/highmed/pseudonymization/translation/ResultSetTranslatorToTtpWithRbfTest.java
@@ -29,9 +29,9 @@ import com.fasterxml.jackson.core.util.DefaultIndenter;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-public class ResultSetTranslatorToTtpTest
+public class ResultSetTranslatorToTtpWithRbfTest
 {
-	private static final Logger logger = LoggerFactory.getLogger(ResultSetTranslatorToTtpTest.class);
+	private static final Logger logger = LoggerFactory.getLogger(ResultSetTranslatorToTtpWithRbfTest.class);
 
 	@Test
 	public void testTranslateForTtp() throws Exception
@@ -61,7 +61,7 @@ public class ResultSetTranslatorToTtpTest
 		String researchStudyIdentifier = "researchStudy1";
 		SecretKey researchStudyKey = AesGcmUtil.generateAES256Key();
 
-		ResultSetTranslatorToTtpImpl translator = new ResultSetTranslatorToTtpImpl(organizationIdentifier,
+		ResultSetTranslatorToTtpWithRbfImpl translator = new ResultSetTranslatorToTtpWithRbfImpl(organizationIdentifier,
 				organizationKey, researchStudyIdentifier, researchStudyKey, "/ehr_status/subject/external_ref/id/value",
 				recordBloomFilterGenerator, masterPatientIndexClient);
 
@@ -122,7 +122,7 @@ public class ResultSetTranslatorToTtpTest
 		String researchStudyIdentifier = "researchStudy1";
 		SecretKey researchStudyKey = AesGcmUtil.generateAES256Key();
 
-		ResultSetTranslatorToTtpImpl translator = new ResultSetTranslatorToTtpImpl(organizationIdentifier,
+		ResultSetTranslatorToTtpWithRbfImpl translator = new ResultSetTranslatorToTtpWithRbfImpl(organizationIdentifier,
 				organizationKey, researchStudyIdentifier, researchStudyKey, "/ehr_status/subject/external_ref/id/value",
 				recordBloomFilterGenerator, masterPatientIndexClient);
 
@@ -170,10 +170,10 @@ public class ResultSetTranslatorToTtpTest
 		String researchStudyIdentifier = "researchStudy1";
 		SecretKey researchStudyKey = AesGcmUtil.generateAES256Key();
 
-		ResultSetTranslatorToTtpImpl translator = new ResultSetTranslatorToTtpImpl(organizationIdentifier,
+		ResultSetTranslatorToTtpWithRbfImpl translator = new ResultSetTranslatorToTtpWithRbfImpl(organizationIdentifier,
 				organizationKey, researchStudyIdentifier, researchStudyKey, "/ehr_status/subject/external_ref/id/value",
 				recordBloomFilterGenerator, masterPatientIndexClient,
-				ResultSetTranslatorToTtpImpl.FILTER_ON_IDAT_NOT_FOUND_EXCEPTION);
+				ResultSetTranslatorToTtpWithRbfImpl.FILTER_ON_IDAT_NOT_FOUND_EXCEPTION);
 
 		ObjectMapper openEhrObjectMapper = OpenEhrObjectMapperFactory.createObjectMapper();
 		ResultSet resultSet = openEhrObjectMapper

--- a/dsf-pseudonymization/dsf-pseudonymization-ttp/src/main/java/org/highmed/pseudonymization/translation/ResultSetTranslatorFromMedicNoRbf.java
+++ b/dsf-pseudonymization/dsf-pseudonymization-ttp/src/main/java/org/highmed/pseudonymization/translation/ResultSetTranslatorFromMedicNoRbf.java
@@ -1,0 +1,5 @@
+package org.highmed.pseudonymization.translation;
+
+public interface ResultSetTranslatorFromMedicNoRbf extends ResultSetTranslatorFromMedic
+{
+}

--- a/dsf-pseudonymization/dsf-pseudonymization-ttp/src/main/java/org/highmed/pseudonymization/translation/ResultSetTranslatorFromMedicNoRbfImpl.java
+++ b/dsf-pseudonymization/dsf-pseudonymization-ttp/src/main/java/org/highmed/pseudonymization/translation/ResultSetTranslatorFromMedicNoRbfImpl.java
@@ -1,0 +1,72 @@
+package org.highmed.pseudonymization.translation;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import org.highmed.openehr.model.datatypes.StringRowElement;
+import org.highmed.openehr.model.structure.Column;
+import org.highmed.openehr.model.structure.ResultSet;
+import org.highmed.openehr.model.structure.RowElement;
+import org.highmed.pseudonymization.domain.PersonWithMdat;
+import org.highmed.pseudonymization.domain.impl.MedicIdImpl;
+import org.highmed.pseudonymization.domain.impl.OpenEhrMdatContainer;
+import org.highmed.pseudonymization.domain.impl.PersonImpl;
+import org.highmed.pseudonymization.openehr.Constants;
+import org.highmed.pseudonymization.recordlinkage.MedicId;
+
+public class ResultSetTranslatorFromMedicNoRbfImpl implements ResultSetTranslatorFromMedicNoRbf
+{
+	@Override
+	public List<PersonWithMdat> translate(String organization, ResultSet resultSet)
+	{
+		int medicIdColumnIndex = getMedicIdColumnIndex(resultSet.getColumns());
+
+		if (medicIdColumnIndex < 0)
+			throw new IllegalArgumentException("Missing MeDIC id column with name '" + Constants.MEDICID_COLUMN_NAME
+					+ "' and path '" + Constants.MEDICID_COLUMN_PATH + "'");
+
+		return resultSet.getRows().parallelStream().map(toPersonWithMdat(organization, medicIdColumnIndex))
+				.collect(Collectors.toList());
+	}
+
+	private Function<List<RowElement>, PersonWithMdat> toPersonWithMdat(String organization, int medicIdColumnIndex)
+	{
+		return rowElements ->
+		{
+			MedicId medicId = getMedicId(organization, rowElements.get(medicIdColumnIndex));
+			List<RowElement> elements = new ArrayList<>();
+			for (int i = 0; i < rowElements.size(); i++)
+				if (i != medicIdColumnIndex)
+					elements.add(rowElements.get(i));
+
+			return new PersonImpl(medicId, null, new OpenEhrMdatContainer(elements));
+		};
+	}
+
+	private MedicId getMedicId(String organization, RowElement rowElement)
+	{
+		if (rowElement instanceof StringRowElement)
+			return new MedicIdImpl(organization, ((StringRowElement) rowElement).getValue());
+		else
+			throw new IllegalArgumentException("RowElement of type " + StringRowElement.class.getName()
+					+ " expected but got " + rowElement.getClass().getName());
+	}
+
+	private int getMedicIdColumnIndex(List<Column> columns)
+	{
+		for (int i = 0; i < columns.size(); i++)
+			if (isMedicIdColumn().test(columns.get(i)))
+				return i;
+
+		return -1;
+	}
+
+	private Predicate<? super Column> isMedicIdColumn()
+	{
+		return column -> Constants.MEDICID_COLUMN_NAME.equals(column.getName())
+				&& Constants.MEDICID_COLUMN_PATH.equals(column.getPath());
+	}
+}

--- a/dsf-pseudonymization/dsf-pseudonymization-ttp/src/main/java/org/highmed/pseudonymization/translation/ResultSetTranslatorFromMedicRbfOnly.java
+++ b/dsf-pseudonymization/dsf-pseudonymization-ttp/src/main/java/org/highmed/pseudonymization/translation/ResultSetTranslatorFromMedicRbfOnly.java
@@ -1,11 +1,5 @@
 package org.highmed.pseudonymization.translation;
 
-import java.util.List;
-
-import org.highmed.openehr.model.structure.ResultSet;
-import org.highmed.pseudonymization.domain.PersonWithMdat;
-
-public interface ResultSetTranslatorFromMedicRbfOnly
+public interface ResultSetTranslatorFromMedicRbfOnly extends ResultSetTranslatorFromMedic
 {
-	List<PersonWithMdat> translate(String organization, ResultSet resultSet);
 }

--- a/dsf-pseudonymization/dsf-pseudonymization-ttp/src/main/java/org/highmed/pseudonymization/translation/ResultSetTranslatorFromMedicWithRbf.java
+++ b/dsf-pseudonymization/dsf-pseudonymization-ttp/src/main/java/org/highmed/pseudonymization/translation/ResultSetTranslatorFromMedicWithRbf.java
@@ -1,0 +1,5 @@
+package org.highmed.pseudonymization.translation;
+
+public interface ResultSetTranslatorFromMedicWithRbf extends ResultSetTranslatorFromMedic
+{
+}

--- a/dsf-pseudonymization/dsf-pseudonymization-ttp/src/main/java/org/highmed/pseudonymization/translation/ResultSetTranslatorFromMedicWithRbfImpl.java
+++ b/dsf-pseudonymization/dsf-pseudonymization-ttp/src/main/java/org/highmed/pseudonymization/translation/ResultSetTranslatorFromMedicWithRbfImpl.java
@@ -19,7 +19,7 @@ import org.highmed.pseudonymization.domain.impl.PersonImpl;
 import org.highmed.pseudonymization.openehr.Constants;
 import org.highmed.pseudonymization.recordlinkage.MedicId;
 
-public class ResultSetTranslatorFromMedicImpl implements ResultSetTranslatorFromMedic
+public class ResultSetTranslatorFromMedicWithRbfImpl implements ResultSetTranslatorFromMedicWithRbf
 {
 	@Override
 	public List<PersonWithMdat> translate(String organization, ResultSet resultSet)

--- a/dsf-pseudonymization/dsf-pseudonymization-ttp/src/test/java/org/highmed/pseudonymization/test/RecordLinkagePseudonymizationIntegrationTest.java
+++ b/dsf-pseudonymization/dsf-pseudonymization-ttp/src/test/java/org/highmed/pseudonymization/test/RecordLinkagePseudonymizationIntegrationTest.java
@@ -23,7 +23,7 @@ import org.highmed.pseudonymization.recordlinkage.FederatedMatcher;
 import org.highmed.pseudonymization.recordlinkage.FederatedMatcherImpl;
 import org.highmed.pseudonymization.recordlinkage.MatchedPerson;
 import org.highmed.pseudonymization.translation.ResultSetTranslatorFromMedic;
-import org.highmed.pseudonymization.translation.ResultSetTranslatorFromMedicImpl;
+import org.highmed.pseudonymization.translation.ResultSetTranslatorFromMedicWithRbfImpl;
 import org.highmed.pseudonymization.translation.ResultSetTranslatorToMedic;
 import org.highmed.pseudonymization.translation.ResultSetTranslatorToMedicImpl;
 import org.junit.Before;
@@ -48,7 +48,7 @@ public class RecordLinkagePseudonymizationIntegrationTest
 	@Before
 	public void before() throws Exception
 	{
-		fromMedic = new ResultSetTranslatorFromMedicImpl();
+		fromMedic = new ResultSetTranslatorFromMedicWithRbfImpl();
 		matcher = new FederatedMatcherImpl<>(MatchedPersonImpl::new);
 		generator = new PseudonymGeneratorImpl<>("researchStudyIdentifier", AesGcmUtil.generateAES256Key(),
 				new ObjectMapper(), PseudonymizedPersonImpl::new);


### PR DESCRIPTION
- Adds result set translators without record-bloom-filter columns
- Adds an additional bpmn execution variable for the leading medic identifier
- Makes AES algorithm string constant public to be used in processes

closes #190 