### PR TITLE
Issues/197-references-related-artifacts

### DIFF
--- a/dsf-fhir/dsf-fhir-rest-adapter/src/main/java/org/highmed/dsf/fhir/service/ReferenceCleanerImpl.java
+++ b/dsf-fhir/dsf-fhir-rest-adapter/src/main/java/org/highmed/dsf/fhir/service/ReferenceCleanerImpl.java
@@ -36,9 +36,12 @@ public class ReferenceCleanerImpl implements ReferenceCleaner
 
 	private void cleanupReference(ResourceReference resourceReference)
 	{
-		Reference ref = resourceReference.getReference();
-		if (ref.hasIdentifier() && ref.hasReference())
-			ref.setReferenceElement((IdType) null);
+		if (resourceReference.hasReference())
+		{
+			Reference ref = resourceReference.getReference();
+			if (ref.hasIdentifier() && ref.hasReference())
+				ref.setReferenceElement((IdType) null);
+		}
 	}
 
 	@Override
@@ -65,7 +68,8 @@ public class ReferenceCleanerImpl implements ReferenceCleaner
 		else
 		{
 			Stream<ResourceReference> references = referenceExtractor.getReferences(resource);
-			references.forEach(r -> r.getReference().setResource(null));
+
+			references.filter(ResourceReference::hasReference).forEach(r -> r.getReference().setResource(null));
 
 			if (resource instanceof DomainResource && ((DomainResource) resource).hasContained())
 			{

--- a/dsf-fhir/dsf-fhir-rest-adapter/src/main/java/org/highmed/dsf/fhir/service/ResourceReference.java
+++ b/dsf-fhir/dsf-fhir-rest-adapter/src/main/java/org/highmed/dsf/fhir/service/ResourceReference.java
@@ -8,6 +8,7 @@ import static org.highmed.dsf.fhir.service.ResourceReference.ReferenceType.RELAT
 import static org.highmed.dsf.fhir.service.ResourceReference.ReferenceType.RELATED_ARTEFACT_LITERAL_EXTERNAL_URL;
 import static org.highmed.dsf.fhir.service.ResourceReference.ReferenceType.RELATED_ARTEFACT_LITERAL_INTERNAL_URL;
 import static org.highmed.dsf.fhir.service.ResourceReference.ReferenceType.RELATED_ARTEFACT_TEMPORARY_URL;
+import static org.highmed.dsf.fhir.service.ResourceReference.ReferenceType.RELATED_ARTEFACT_UNKNOWN_URL;
 import static org.highmed.dsf.fhir.service.ResourceReference.ReferenceType.TEMPORARY;
 import static org.highmed.dsf.fhir.service.ResourceReference.ReferenceType.UNKNOWN;
 
@@ -111,6 +112,10 @@ public class ResourceReference
 		 */
 		CONDITIONAL,
 		/**
+		 * unknown reference
+		 */
+		UNKNOWN,
+		/**
 		 * temporary url in RelatedArtifact starting with <code>urn:uuid:</code>
 		 */
 		RELATED_ARTEFACT_TEMPORARY_URL,
@@ -125,7 +130,11 @@ public class ResourceReference
 		/**
 		 * literal url in RelatedArtifact to a resource on an external server
 		 */
-		RELATED_ARTEFACT_LITERAL_EXTERNAL_URL, UNKNOWN
+		RELATED_ARTEFACT_LITERAL_EXTERNAL_URL,
+		/**
+		 * unknown url in RelatedArtifact
+		 */
+		RELATED_ARTEFACT_UNKNOWN_URL
 	}
 
 	private final String location;
@@ -148,6 +157,10 @@ public class ResourceReference
 			Collection<Class<? extends Resource>> referenceTypes)
 	{
 		this.location = location;
+
+		if (reference == null && relatedArtifact == null)
+			throw new IllegalArgumentException("Either reference or relatedArtifact expected");
+
 		this.reference = reference;
 		this.relatedArtifact = relatedArtifact;
 
@@ -203,7 +216,8 @@ public class ResourceReference
 	 * @return one of this priority list: {@link ReferenceType#RELATED_ARTEFACT_TEMPORARY_URL},
 	 *         {@link ReferenceType#RELATED_ARTEFACT_LITERAL_INTERNAL_URL},
 	 *         {@link ReferenceType#RELATED_ARTEFACT_LITERAL_EXTERNAL_URL},
-	 *         {@link ReferenceType#RELATED_ARTEFACT_CONDITIONAL_URL}, {@link ReferenceType#TEMPORARY},
+	 *         {@link ReferenceType#RELATED_ARTEFACT_CONDITIONAL_URL},
+	 *         {@link ReferenceType#RELATED_ARTEFACT_UNKNOWN_URL}, {@link ReferenceType#TEMPORARY},
 	 *         {@link ReferenceType#LITERAL_INTERNAL}, {@link ReferenceType#LITERAL_EXTERNAL},
 	 *         {@link ReferenceType#CONDITIONAL}, {@link ReferenceType#LOGICAL}, {@link ReferenceType#UNKNOWN}
 	 */
@@ -233,6 +247,8 @@ public class ResourceReference
 				if (conditionalRefMatcher.matches())
 					return RELATED_ARTEFACT_CONDITIONAL_URL;
 			}
+
+			return RELATED_ARTEFACT_UNKNOWN_URL;
 		}
 		else if (reference != null)
 		{
@@ -261,9 +277,11 @@ public class ResourceReference
 			{
 				return LOGICAL;
 			}
-		}
 
-		return UNKNOWN;
+			return UNKNOWN;
+		}
+		else
+			throw new IllegalStateException("Either reference or relatedArtifact expected");
 	}
 
 	public String getLocation()

--- a/dsf-fhir/dsf-fhir-rest-adapter/src/test/java/org/highmed/dsf/fhir/service/ReferenceExtractorTest.java
+++ b/dsf-fhir/dsf-fhir-rest-adapter/src/test/java/org/highmed/dsf/fhir/service/ReferenceExtractorTest.java
@@ -1,6 +1,7 @@
 package org.highmed.dsf.fhir.service;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -42,7 +43,7 @@ public class ReferenceExtractorTest
 
 		List<ResourceReference> refs = referenceExtractor.getReferences(t).collect(Collectors.toList());
 
-		logger.debug("refs: {}", refs.stream().map(r -> r.getReferenceLocation()).collect(Collectors.toList()));
+		logger.debug("refs: {}", refs.stream().map(ResourceReference::getLocation).collect(Collectors.toList()));
 
 		assertNotNull(refs);
 		assertEquals(4, refs.size());

--- a/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/authentication/UserProvider.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/authentication/UserProvider.java
@@ -8,7 +8,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response.Status;
 
-import org.hl7.fhir.r4.model.Organization;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,5 +52,4 @@ public class UserProvider
 			throw new WebApplicationException(Status.FORBIDDEN);
 		}
 	}
-
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/dao/ResourceDao.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/dao/ResourceDao.java
@@ -13,7 +13,6 @@ import org.highmed.dsf.fhir.dao.exception.ResourceVersionNoMatchException;
 import org.highmed.dsf.fhir.search.DbSearchQuery;
 import org.highmed.dsf.fhir.search.PartialResult;
 import org.highmed.dsf.fhir.search.SearchQuery;
-import org.hl7.fhir.r4.model.DomainResource;
 import org.hl7.fhir.r4.model.Resource;
 
 public interface ResourceDao<R extends Resource>

--- a/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/dao/command/CreateCommand.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/dao/command/CreateCommand.java
@@ -129,7 +129,8 @@ public class CreateCommand<R extends Resource, D extends ResourceDao<R>> extends
 			throws SQLException, WebApplicationException
 	{
 		// always resolve temp and conditional references, necessary if conditional create and resource exists
-		referencesHelper.resolveTemporaryAndConditionalReferences(idTranslationTable, connection);
+		referencesHelper.resolveTemporaryAndConditionalReferencesOrLiteralInternalRelatedArtifactUrls(
+				idTranslationTable, connection);
 
 		// checking again if resource exists, could be that a previous command created, or deleted it
 		Optional<Resource> exists = checkAlreadyExists(connection, entry.getRequest().getIfNoneExist(),

--- a/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/dao/command/ReferencesHelper.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/dao/command/ReferencesHelper.java
@@ -10,8 +10,8 @@ import org.hl7.fhir.r4.model.Resource;
 
 public interface ReferencesHelper<R extends Resource>
 {
-	void resolveTemporaryAndConditionalReferences(Map<String, IdType> idTranslationTable, Connection connection)
-			throws WebApplicationException;
+	void resolveTemporaryAndConditionalReferencesOrLiteralInternalRelatedArtifactUrls(
+			Map<String, IdType> idTranslationTable, Connection connection) throws WebApplicationException;
 
 	void resolveLogicalReferences(Connection connection) throws WebApplicationException;
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/dao/command/UpdateCommand.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/dao/command/UpdateCommand.java
@@ -291,7 +291,8 @@ public class UpdateCommand<R extends Resource, D extends ResourceDao<R>> extends
 		}
 		else
 		{
-			referencesHelper.resolveTemporaryAndConditionalReferences(idTranslationTable, connection);
+			referencesHelper.resolveTemporaryAndConditionalReferencesOrLiteralInternalRelatedArtifactUrls(
+					idTranslationTable, connection);
 
 			validationResult = validationHelper.checkResourceValidForUpdate(user, resource);
 
@@ -307,7 +308,8 @@ public class UpdateCommand<R extends Resource, D extends ResourceDao<R>> extends
 	{
 		if (Boolean.FALSE.equals(foundByCondition))
 		{
-			referencesHelper.resolveTemporaryAndConditionalReferences(idTranslationTable, connection);
+			referencesHelper.resolveTemporaryAndConditionalReferencesOrLiteralInternalRelatedArtifactUrls(
+					idTranslationTable, connection);
 
 			validationResult = validationHelper.checkResourceValidForCreate(user, resource);
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/help/ResponseGenerator.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/help/ResponseGenerator.java
@@ -402,15 +402,14 @@ public class ResponseGenerator
 			Integer bundleIndex)
 	{
 		if (bundleIndex == null)
-			logger.warn("Unknown reference at {} in resource of type {} with id {}",
-					resourceReference.getReferenceLocation(), resource.getResourceType().name(), resource.getId());
+			logger.warn("Unknown reference at {} in resource of type {} with id {}", resourceReference.getLocation(),
+					resource.getResourceType().name(), resource.getId());
 		else
 			logger.warn("Unknown reference at {} in resource of type {} with id {} at bundle index {}",
-					resourceReference.getReferenceLocation(), resource.getResourceType().name(), resource.getId(),
-					bundleIndex);
+					resourceReference.getLocation(), resource.getResourceType().name(), resource.getId(), bundleIndex);
 
 		return createOutcome(IssueSeverity.ERROR, IssueType.PROCESSING,
-				"Unknown reference at " + resourceReference.getReferenceLocation() + " in resource of type "
+				"Unknown reference at " + resourceReference.getLocation() + " in resource of type "
 						+ resource.getResourceType().name() + " with id " + resource.getId()
 						+ (bundleIndex == null ? "" : " at bundle index " + bundleIndex));
 	}
@@ -421,16 +420,15 @@ public class ResponseGenerator
 		if (bundleIndex == null)
 			logger.warn(
 					"Reference target type of reference at {} in resource of type {} with id {} not supported by this implementation",
-					resourceReference.getReferenceLocation(), resource.getResourceType().name(), resource.getId());
+					resourceReference.getLocation(), resource.getResourceType().name(), resource.getId());
 		else
 			logger.warn(
 					"Reference target type of reference at {} in resource of type {} with id {} at bundle index {} not supported by this implementation",
-					resourceReference.getReferenceLocation(), resource.getResourceType().name(), resource.getId(),
-					bundleIndex);
+					resourceReference.getLocation(), resource.getResourceType().name(), resource.getId(), bundleIndex);
 
 		return createOutcome(IssueSeverity.ERROR, IssueType.PROCESSING,
-				"Reference target type of reference at " + resourceReference.getReferenceLocation()
-						+ " in resource of type " + resource.getResourceType().name() + " with id " + resource.getId()
+				"Reference target type of reference at " + resourceReference.getLocation() + " in resource of type "
+						+ resource.getResourceType().name() + " with id " + resource.getId()
 						+ (bundleIndex == null ? "" : " at bundle index " + bundleIndex)
 						+ " not supported by this implementation");
 	}
@@ -440,16 +438,15 @@ public class ResponseGenerator
 	{
 		if (bundleIndex == null)
 			logger.warn("Reference target type of reference at {} in resource of type {} with id {} not supported",
-					resourceReference.getReferenceLocation(), resource.getResourceType().name(), resource.getId());
+					resourceReference.getLocation(), resource.getResourceType().name(), resource.getId());
 		else
 			logger.warn(
 					"Reference target type of reference at {} in resource of type {} with id {} at bundle index {} not supported",
-					resourceReference.getReferenceLocation(), resource.getResourceType().name(), resource.getId(),
-					bundleIndex);
+					resourceReference.getLocation(), resource.getResourceType().name(), resource.getId(), bundleIndex);
 
 		return createOutcome(IssueSeverity.ERROR, IssueType.PROCESSING,
-				"Reference target type of reference at " + resourceReference.getReferenceLocation()
-						+ " in resource of type " + resource.getResourceType().name() + " with id " + resource.getId()
+				"Reference target type of reference at " + resourceReference.getLocation() + " in resource of type "
+						+ resource.getResourceType().name() + " with id " + resource.getId()
 						+ (bundleIndex == null ? "" : " at bundle index " + bundleIndex) + " not supported");
 	}
 
@@ -458,18 +455,18 @@ public class ResponseGenerator
 	{
 		if (bundleIndex == null)
 			logger.warn("Reference target {} of reference at {} in resource of type {} with id {} not found",
-					resourceReference.getReference().getReference(), resourceReference.getReferenceLocation(),
-					resource.getResourceType().name(), resource.getId());
+					resourceReference.getValue(), resourceReference.getLocation(), resource.getResourceType().name(),
+					resource.getId());
 		else
 			logger.warn(
 					"Reference target {} of reference at {} in resource of type {} with id {} at bundle index {} not found",
-					resourceReference.getReference().getReference(), resourceReference.getReferenceLocation(),
-					resource.getResourceType().name(), resource.getId(), bundleIndex);
+					resourceReference.getValue(), resourceReference.getLocation(), resource.getResourceType().name(),
+					resource.getId(), bundleIndex);
 
 		return createOutcome(IssueSeverity.ERROR, IssueType.PROCESSING,
-				"Reference target " + resourceReference.getReference().getReference() + " of reference at "
-						+ resourceReference.getReferenceLocation() + " in resource of type "
-						+ resource.getResourceType().name() + " with id " + resource.getId()
+				"Reference target " + resourceReference.getValue() + " of reference at "
+						+ resourceReference.getLocation() + " in resource of type " + resource.getResourceType().name()
+						+ " with id " + resource.getId()
 						+ (bundleIndex == null ? "" : " at bundle index " + bundleIndex) + " not found");
 	}
 
@@ -479,18 +476,18 @@ public class ResponseGenerator
 		if (bundleIndex == null)
 			logger.warn(
 					"Reference target {} of reference at {} in resource of type {} with id {} not found on server {}",
-					resourceReference.getReference().getReference(), resourceReference.getReferenceLocation(),
-					resource.getResourceType().name(), resource.getId(), serverBase);
+					resourceReference.getValue(), resourceReference.getLocation(), resource.getResourceType().name(),
+					resource.getId(), serverBase);
 		else
 			logger.warn(
 					"Reference target {} of reference at {} in resource of type {} with id {} at bundle index {} not found on server {}",
-					resourceReference.getReference().getReference(), resourceReference.getReferenceLocation(),
-					resource.getResourceType().name(), resource.getId(), bundleIndex, serverBase);
+					resourceReference.getValue(), resourceReference.getLocation(), resource.getResourceType().name(),
+					resource.getId(), bundleIndex, serverBase);
 
 		return createOutcome(IssueSeverity.ERROR, IssueType.PROCESSING,
-				"Reference target " + resourceReference.getReference().getReference() + " of reference at "
-						+ resourceReference.getReferenceLocation() + " in resource of type "
-						+ resource.getResourceType().name() + " with id " + resource.getId()
+				"Reference target " + resourceReference.getValue() + " of reference at "
+						+ resourceReference.getLocation() + " in resource of type " + resource.getResourceType().name()
+						+ " with id " + resource.getId()
 						+ (bundleIndex == null ? "" : " at bundle index " + bundleIndex) + " not found on server "
 						+ serverBase);
 	}
@@ -501,18 +498,18 @@ public class ResponseGenerator
 		if (bundleIndex == null)
 			logger.warn(
 					"No Endpoint found for reference target {} of reference at {} in resource of type {} with id {}",
-					resourceReference.getReference().getReference(), resourceReference.getReferenceLocation(),
-					resource.getResourceType().name(), resource.getId());
+					resourceReference.getValue(), resourceReference.getLocation(), resource.getResourceType().name(),
+					resource.getId());
 		else
 			logger.warn(
 					"No Endpoint found for reference target {} of reference at {} in resource of type {} with id {} at bundle index {} not found",
-					resourceReference.getReference().getReference(), resourceReference.getReferenceLocation(),
-					resource.getResourceType().name(), resource.getId(), bundleIndex);
+					resourceReference.getValue(), resourceReference.getLocation(), resource.getResourceType().name(),
+					resource.getId(), bundleIndex);
 
 		return createOutcome(IssueSeverity.ERROR, IssueType.PROCESSING,
-				"No Endpoint found for reference target " + resourceReference.getReference().getReference()
-						+ " of reference at " + resourceReference.getReferenceLocation() + " in resource of type "
-						+ resource.getResourceType().name() + " with id " + resource.getId()
+				"No Endpoint found for reference target " + resourceReference.getValue() + " of reference at "
+						+ resourceReference.getLocation() + " in resource of type " + resource.getResourceType().name()
+						+ " with id " + resource.getId()
 						+ (bundleIndex == null ? "" : " at bundle index " + bundleIndex) + " not found");
 	}
 
@@ -526,20 +523,20 @@ public class ResponseGenerator
 		if (bundleIndex == null)
 			logger.warn(
 					"{} reference {} at {} in resource of type {} with id {} contains unsupported queryparameter{} {}",
-					logicalNotConditional ? "Logical" : "Conditional", queryParameters,
-					resourceReference.getReferenceLocation(), resource.getResourceType().name(), resource.getId(),
+					logicalNotConditional ? "Logical" : "Conditional", queryParameters, resourceReference.getLocation(),
+					resource.getResourceType().name(), resource.getId(),
 					unsupportedQueryParameters.size() != 1 ? "s" : "", unsupportedQueryParametersString);
 		else
 			logger.warn(
 					"{} reference {} at {} in resource of type {} with id {} at bundle index {} contains unsupported queryparameter{} {}",
-					logicalNotConditional ? "Logical" : "Conditional", queryParameters,
-					resourceReference.getReferenceLocation(), resource.getResourceType().name(), resource.getId(),
-					bundleIndex, unsupportedQueryParameters.size() != 1 ? "s" : "", unsupportedQueryParametersString);
+					logicalNotConditional ? "Logical" : "Conditional", queryParameters, resourceReference.getLocation(),
+					resource.getResourceType().name(), resource.getId(), bundleIndex,
+					unsupportedQueryParameters.size() != 1 ? "s" : "", unsupportedQueryParametersString);
 
 		return createOutcome(IssueSeverity.ERROR, IssueType.PROCESSING,
 				(logicalNotConditional ? "Logical" : "Conditional") + " reference " + queryParameters + " at "
-						+ resourceReference.getReferenceLocation() + " in resource of type "
-						+ resource.getResourceType().name() + " with id " + resource.getId()
+						+ resourceReference.getLocation() + " in resource of type " + resource.getResourceType().name()
+						+ " with id " + resource.getId()
 						+ (bundleIndex == null ? "" : " at bundle index " + bundleIndex)
 						+ " contains unsupported queryparameter" + (unsupportedQueryParameters.size() != 1 ? "s" : "")
 						+ " " + unsupportedQueryParametersString);
@@ -558,21 +555,20 @@ public class ResponseGenerator
 			logger.warn(
 					"Reference target by identifier '{}|{}' of reference at {} in resource of type {} with id {} not found",
 					resourceReference.getReference().getIdentifier().getSystem(),
-					resourceReference.getReference().getIdentifier().getValue(),
-					resourceReference.getReferenceLocation(), resource.getResourceType().name(), resource.getId());
+					resourceReference.getReference().getIdentifier().getValue(), resourceReference.getLocation(),
+					resource.getResourceType().name(), resource.getId());
 		else
 			logger.warn(
 					"Reference target by identifier '{}|{}' of reference at {} in resource of type {} with id {} at bundle index {} not found",
 					resourceReference.getReference().getIdentifier().getSystem(),
-					resourceReference.getReference().getIdentifier().getValue(),
-					resourceReference.getReferenceLocation(), resource.getResourceType().name(), resource.getId(),
-					bundleIndex);
+					resourceReference.getReference().getIdentifier().getValue(), resourceReference.getLocation(),
+					resource.getResourceType().name(), resource.getId(), bundleIndex);
 
 		return createOutcome(IssueSeverity.ERROR, IssueType.PROCESSING,
 				"Reference target by identifier '" + resourceReference.getReference().getIdentifier().getSystem() + "|"
 						+ resourceReference.getReference().getIdentifier().getValue() + "' of reference at "
-						+ resourceReference.getReferenceLocation() + " in resource of type "
-						+ resource.getResourceType().name() + " with id " + resource.getId()
+						+ resourceReference.getLocation() + " in resource of type " + resource.getResourceType().name()
+						+ " with id " + resource.getId()
 						+ (bundleIndex == null ? "" : " at bundle index " + bundleIndex) + " not found");
 	}
 
@@ -583,22 +579,21 @@ public class ResponseGenerator
 			logger.warn(
 					"Found {} matches for reference target by identifier '{}|{}' of reference at {} in resource of type {} with id {}",
 					overallCount, resourceReference.getReference().getIdentifier().getSystem(),
-					resourceReference.getReference().getIdentifier().getValue(),
-					resourceReference.getReferenceLocation(), resource.getResourceType().name(), resource.getId());
+					resourceReference.getReference().getIdentifier().getValue(), resourceReference.getLocation(),
+					resource.getResourceType().name(), resource.getId());
 		else
 			logger.warn(
 					"Found {} matches for reference target by identifier '{}|{}' of reference at {} in resource of type {} with id {} at bundle index {}",
 					overallCount, resourceReference.getReference().getIdentifier().getSystem(),
-					resourceReference.getReference().getIdentifier().getValue(),
-					resourceReference.getReferenceLocation(), resource.getResourceType().name(), resource.getId(),
-					bundleIndex);
+					resourceReference.getReference().getIdentifier().getValue(), resourceReference.getLocation(),
+					resource.getResourceType().name(), resource.getId(), bundleIndex);
 
 		return createOutcome(IssueSeverity.ERROR, IssueType.PROCESSING,
 				"Found " + overallCount + " matches for reference target by identifier '"
 						+ resourceReference.getReference().getIdentifier().getSystem() + "|"
 						+ resourceReference.getReference().getIdentifier().getValue() + "' of reference at "
-						+ resourceReference.getReferenceLocation() + " in resource of type "
-						+ resource.getResourceType().name() + " with id " + resource.getId()
+						+ resourceReference.getLocation() + " in resource of type " + resource.getResourceType().name()
+						+ " with id " + resource.getId()
 						+ (bundleIndex == null ? "" : " at bundle index " + bundleIndex) + " not found");
 	}
 
@@ -608,18 +603,18 @@ public class ResponseGenerator
 		if (bundleIndex == null)
 			logger.warn(
 					"Reference target by condition '{}' of reference at {} in resource of type {} with id {} not found",
-					resourceReference.getReference().getReference(), resourceReference.getReferenceLocation(),
-					resource.getResourceType().name(), resource.getId());
+					resourceReference.getValue(), resourceReference.getLocation(), resource.getResourceType().name(),
+					resource.getId());
 		else
 			logger.warn(
 					"Reference target by condition '{}' of reference at {} in resource of type {} with id {} at bundle index {} not found",
-					resourceReference.getReference().getReference(), resourceReference.getReferenceLocation(),
-					resource.getResourceType().name(), resource.getId(), bundleIndex);
+					resourceReference.getValue(), resourceReference.getLocation(), resource.getResourceType().name(),
+					resource.getId(), bundleIndex);
 
 		return createOutcome(IssueSeverity.ERROR, IssueType.PROCESSING,
-				"Reference target by condition '" + resourceReference.getReference().getReference()
-						+ "' of reference at " + resourceReference.getReferenceLocation() + " in resource of type "
-						+ resource.getResourceType().name() + " with id " + resource.getId()
+				"Reference target by condition '" + resourceReference.getValue() + "' of reference at "
+						+ resourceReference.getLocation() + " in resource of type " + resource.getResourceType().name()
+						+ " with id " + resource.getId()
 						+ (bundleIndex == null ? "" : " at bundle index " + bundleIndex) + " not found");
 	}
 
@@ -629,19 +624,17 @@ public class ResponseGenerator
 		if (bundleIndex == null)
 			logger.warn(
 					"Found {} matches for reference target by condition '{}' of reference at {} in resource of type {} with id {}",
-					overallCount, resourceReference.getReference().getReference(),
-					resourceReference.getReferenceLocation(), resource.getResourceType().name(), resource.getId());
+					overallCount, resourceReference.getValue(), resourceReference.getLocation(),
+					resource.getResourceType().name(), resource.getId());
 		else
 			logger.warn(
 					"Found {} matches for reference target by condition '{}' of reference at {} in resource of type {} with id {} at bundle index {}",
-					overallCount, resourceReference.getReference().getReference(),
-					resourceReference.getReferenceLocation(), resource.getResourceType().name(), resource.getId(),
-					bundleIndex);
+					overallCount, resourceReference.getValue(), resourceReference.getLocation(),
+					resource.getResourceType().name(), resource.getId(), bundleIndex);
 
 		return createOutcome(IssueSeverity.ERROR, IssueType.PROCESSING,
-				"Found " + overallCount + " matches for reference target by condition '"
-						+ resourceReference.getReference().getReference() + "' of reference at "
-						+ resourceReference.getReferenceLocation() + " in resource of type "
+				"Found " + overallCount + " matches for reference target by condition '" + resourceReference.getValue()
+						+ "' of reference at " + resourceReference.getLocation() + " in resource of type "
 						+ resource.getResourceType().name() + " with id " + resource.getId()
 						+ (bundleIndex == null ? "" : " at bundle index " + bundleIndex) + " not found");
 	}
@@ -651,18 +644,18 @@ public class ResponseGenerator
 	{
 		if (bundleIndex == null)
 			logger.warn("Bad conditional reference target '{}' of reference at {} in resource of type {} with id {}",
-					resourceReference.getReference().getReference(), resourceReference.getReferenceLocation(),
-					resource.getResourceType().name(), resource.getId());
+					resourceReference.getValue(), resourceReference.getLocation(), resource.getResourceType().name(),
+					resource.getId());
 		else
 			logger.warn(
 					"Bad conditional reference target '{}' of reference at {} in resource of type {} with id {} at bundle index {}",
-					resourceReference.getReference().getReference(), resourceReference.getReferenceLocation(),
-					resource.getResourceType().name(), resource.getId(), bundleIndex);
+					resourceReference.getValue(), resourceReference.getLocation(), resource.getResourceType().name(),
+					resource.getId(), bundleIndex);
 
 		return createOutcome(IssueSeverity.ERROR, IssueType.PROCESSING,
-				"Bad conditional reference target '" + resourceReference.getReference().getReference()
-						+ "' of reference at " + resourceReference.getReferenceLocation() + " in resource of type "
-						+ resource.getResourceType().name() + " with id " + resource.getId()
+				"Bad conditional reference target '" + resourceReference.getValue() + "' of reference at "
+						+ resourceReference.getLocation() + " in resource of type " + resource.getResourceType().name()
+						+ " with id " + resource.getId()
 						+ (bundleIndex == null ? "" : " at bundle index " + bundleIndex) + " not found");
 	}
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/service/ReferenceResolverImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/service/ReferenceResolverImpl.java
@@ -80,9 +80,10 @@ public class ReferenceResolverImpl implements ReferenceResolver, InitializingBea
 			case LITERAL_INTERNAL:
 				return resolveLiteralInternalReference(reference, connection);
 			case LITERAL_EXTERNAL:
+			case RELATED_ARTEFACT_LITERAL_EXTERNAL_URL:
 				return resolveLiteralExternalReference(reference);
-			case RELATED_ARTEFACT_CONDITIONAL_URL:
 			case CONDITIONAL:
+			case RELATED_ARTEFACT_CONDITIONAL_URL:
 				return resolveConditionalReference(user, reference, connection);
 			case LOGICAL:
 				return resolveLogicalReference(user, reference, connection);
@@ -144,8 +145,10 @@ public class ReferenceResolverImpl implements ReferenceResolver, InitializingBea
 		Objects.requireNonNull(reference, "reference");
 
 		ReferenceType type = reference.getType(serverBase);
-		if (!ReferenceType.LITERAL_EXTERNAL.equals(type))
-			throw new IllegalArgumentException("Not a literal external reference");
+		if (!(ReferenceType.LITERAL_EXTERNAL.equals(type)
+				|| ReferenceType.RELATED_ARTEFACT_LITERAL_EXTERNAL_URL.equals(type)))
+			throw new IllegalArgumentException(
+					"Not a literal external reference or related artifact literal external url");
 
 		String remoteServerBase = reference.getServerBase(serverBase);
 		Optional<FhirWebserviceClient> client = clientProvider.getClient(remoteServerBase);

--- a/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/service/ReferenceResolverImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/service/ReferenceResolverImpl.java
@@ -81,6 +81,7 @@ public class ReferenceResolverImpl implements ReferenceResolver, InitializingBea
 				return resolveLiteralInternalReference(reference, connection);
 			case LITERAL_EXTERNAL:
 				return resolveLiteralExternalReference(reference);
+			case RELATED_ARTEFACT_CONDITIONAL_URL:
 			case CONDITIONAL:
 				return resolveConditionalReference(user, reference, connection);
 			case LOGICAL:
@@ -104,7 +105,7 @@ public class ReferenceResolverImpl implements ReferenceResolver, InitializingBea
 		if (referenceDao.isEmpty())
 		{
 			logger.warn("Reference target type of reference at {} not supported by this implementation",
-					reference.getReferenceLocation());
+					reference.getLocation());
 			return Optional.empty();
 		}
 		else
@@ -113,7 +114,7 @@ public class ReferenceResolverImpl implements ReferenceResolver, InitializingBea
 			ResourceDao<Resource> d = (ResourceDao<Resource>) referenceDao.get();
 			if (!reference.supportsType(d.getResourceType()))
 			{
-				logger.warn("Reference target type of reference at {} not supported", reference.getReferenceLocation());
+				logger.warn("Reference target type of reference at {} not supported", reference.getLocation());
 				return Optional.empty();
 			}
 
@@ -176,15 +177,17 @@ public class ReferenceResolverImpl implements ReferenceResolver, InitializingBea
 		Objects.requireNonNull(reference, "reference");
 
 		ReferenceType type = reference.getType(serverBase);
-		if (!ReferenceType.CONDITIONAL.equals(type))
-			throw new IllegalArgumentException("Not a conditional reference");
+		if (!(ReferenceType.CONDITIONAL.equals(type) || ReferenceType.RELATED_ARTEFACT_CONDITIONAL_URL.equals(type)))
+			throw new IllegalArgumentException("Not a conditional reference or a conditional related artifact url");
 
-		UriComponents condition = UriComponentsBuilder.fromUriString(reference.getReference().getReference()).build();
+		String referenceValue = reference.getValue();
+		String referenceLocation = reference.getLocation();
+
+		UriComponents condition = UriComponentsBuilder.fromUriString(referenceValue).build();
 		String path = condition.getPath();
 		if (path == null || path.isBlank())
 		{
-			logger.warn("Bad conditional reference target '{}' of reference at {}",
-					reference.getReference().getReference(), reference.getReferenceLocation());
+			logger.warn("Bad conditional reference target '{}' of reference at {}", referenceValue, referenceLocation);
 			return Optional.empty();
 		}
 
@@ -193,7 +196,7 @@ public class ReferenceResolverImpl implements ReferenceResolver, InitializingBea
 		if (referenceDao.isEmpty())
 		{
 			logger.warn("Reference target type of reference at {} not supported by this implementation",
-					reference.getReferenceLocation());
+					referenceLocation);
 			return Optional.empty();
 		}
 		else
@@ -201,7 +204,7 @@ public class ReferenceResolverImpl implements ReferenceResolver, InitializingBea
 			ResourceDao<?> d = referenceDao.get();
 			if (!reference.supportsType(d.getResourceType()))
 			{
-				logger.warn("Reference target type of reference at {} not supported", reference.getReferenceLocation());
+				logger.warn("Reference target type of reference at {} not supported", referenceLocation);
 				return Optional.empty();
 			}
 
@@ -224,7 +227,7 @@ public class ReferenceResolverImpl implements ReferenceResolver, InitializingBea
 		if (referenceDao.isEmpty())
 		{
 			logger.warn("Reference target type of reference at {} not supported by this implementation",
-					reference.getReferenceLocation());
+					reference.getLocation());
 			return Optional.empty();
 		}
 		else
@@ -233,7 +236,7 @@ public class ReferenceResolverImpl implements ReferenceResolver, InitializingBea
 			if (!reference.supportsType(d.getResourceType()))
 			{
 				logger.warn("Reference target type of reference at {} not supported by this implementation",
-						reference.getReferenceLocation());
+						reference.getLocation());
 				return Optional.empty();
 			}
 
@@ -271,9 +274,8 @@ public class ReferenceResolverImpl implements ReferenceResolver, InitializingBea
 					.map(SearchQueryParameterError::toString).collect(Collectors.joining("; "));
 
 			logger.warn("{} reference {} at {} in resource contains unsupported queryparameter{} {}",
-					logicalNotConditional ? "Logical" : "Conditional", queryParameters,
-					resourceReference.getReferenceLocation(), unsupportedQueryParameters.size() != 1 ? "s" : "",
-					unsupportedQueryParametersString);
+					logicalNotConditional ? "Logical" : "Conditional", queryParameters, resourceReference.getLocation(),
+					unsupportedQueryParameters.size() != 1 ? "s" : "", unsupportedQueryParametersString);
 
 			return Optional.empty();
 		}
@@ -291,13 +293,12 @@ public class ReferenceResolverImpl implements ReferenceResolver, InitializingBea
 			if (logicalNotConditional)
 				logger.warn("Reference target by identifier '{}|{}' of reference at {} in resource",
 						resourceReference.getReference().getIdentifier().getSystem(),
-						resourceReference.getReference().getIdentifier().getValue(),
-						resourceReference.getReferenceLocation());
+						resourceReference.getReference().getIdentifier().getValue(), resourceReference.getLocation());
 			else
 				logger.warn("Reference target by condition '{}' of reference at {} in resource",
 						UriComponentsBuilder.newInstance().path(referenceTargetDao.getResourceTypeName())
 								.replaceQueryParams(CollectionUtils.toMultiValueMap(queryParameters)).toUriString(),
-						resourceReference.getReferenceLocation());
+						resourceReference.getLocation());
 			return Optional.empty();
 		}
 		else if (result.getTotal() == 1)
@@ -312,14 +313,13 @@ public class ReferenceResolverImpl implements ReferenceResolver, InitializingBea
 				logger.warn(
 						"Found {} matches for reference target by identifier '{}|{}' of reference at {} in resource",
 						overallCount, resourceReference.getReference().getIdentifier().getSystem(),
-						resourceReference.getReference().getIdentifier().getValue(),
-						resourceReference.getReferenceLocation());
+						resourceReference.getReference().getIdentifier().getValue(), resourceReference.getLocation());
 			else
 				logger.warn("Found {} matches for reference target by condition '{}' of reference at {} in resource",
 						overallCount,
 						UriComponentsBuilder.newInstance().path(referenceTargetDao.getResourceTypeName())
 								.replaceQueryParams(CollectionUtils.toMultiValueMap(queryParameters)).toUriString(),
-						resourceReference.getReferenceLocation());
+						resourceReference.getLocation());
 
 			return Optional.empty();
 		}
@@ -341,10 +341,12 @@ public class ReferenceResolverImpl implements ReferenceResolver, InitializingBea
 		Objects.requireNonNull(connection, "connection");
 
 		ReferenceType type = reference.getType(serverBase);
-		if (!ReferenceType.LITERAL_INTERNAL.equals(type))
-			throw new IllegalArgumentException("Not a literal internal reference");
+		if (!(ReferenceType.LITERAL_INTERNAL.equals(type)
+				|| ReferenceType.RELATED_ARTEFACT_LITERAL_INTERNAL_URL.equals(type)))
+			throw new IllegalArgumentException(
+					"Not a literal internal reference or related artifact literal internal url");
 
-		IdType id = new IdType(reference.getReference().getReference());
+		IdType id = new IdType(reference.getValue());
 		Optional<ResourceDao<?>> referenceDao = daoProvider.getDao(id.getResourceType());
 
 		if (referenceDao.isEmpty())
@@ -381,30 +383,33 @@ public class ReferenceResolverImpl implements ReferenceResolver, InitializingBea
 		Objects.requireNonNull(reference, "reference");
 
 		ReferenceType type = reference.getType(serverBase);
-		if (!ReferenceType.LITERAL_EXTERNAL.equals(type))
-			throw new IllegalArgumentException("Not a literal external reference");
+		if (!(ReferenceType.LITERAL_EXTERNAL.equals(type)
+				|| ReferenceType.RELATED_ARTEFACT_LITERAL_EXTERNAL_URL.equals(type)))
+			throw new IllegalArgumentException(
+					"Not a literal external reference or related artifact literal external url");
 
 		String remoteServerBase = reference.getServerBase(serverBase);
+		String referenceValue = reference.getValue();
 		Optional<FhirWebserviceClient> client = clientProvider.getClient(remoteServerBase);
 
 		if (client.isEmpty())
 		{
 			logger.error(
 					"Error while resolving literal external reference {}, no remote client found for server base {}",
-					reference.getReference().getReference(), remoteServerBase);
+					referenceValue, remoteServerBase);
 			return Optional
 					.of(responseGenerator.noEndpointFoundForLiteralExternalReference(bundleIndex, resource, reference));
 		}
 		else
 		{
-			IdType referenceId = new IdType(reference.getReference().getReference());
-			logger.debug("Trying to resolve literal external reference {}, at remote server {}",
-					reference.getReference().getReference(), remoteServerBase);
+			IdType referenceId = new IdType(referenceValue);
+			logger.debug("Trying to resolve literal external reference {}, at remote server {}", referenceValue,
+					remoteServerBase);
 			if (!client.get().exists(referenceId))
 			{
 				logger.error(
 						"Error while resolving literal external reference {}, resource could not be found on remote server {}",
-						reference.getReference().getReference(), remoteServerBase);
+						referenceValue, remoteServerBase);
 				return Optional.of(responseGenerator.referenceTargetNotFoundRemote(bundleIndex, resource, reference,
 						remoteServerBase));
 			}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/spring/config/WebserviceConfig.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/spring/config/WebserviceConfig.java
@@ -172,9 +172,9 @@ public class WebserviceConfig
 	{
 		return new ActivityDefinitionServiceSecure(activityDefinitionServiceImpl(), serverBase,
 				helperConfig.responseGenerator(), referenceConfig.referenceResolver(),
-				referenceConfig.referenceCleaner(), daoConfig.activityDefinitionDao(), helperConfig.exceptionHandler(),
-				helperConfig.parameterConverter(), authorizationConfig.activityDefinitionAuthorizationRule(),
-				validationConfig.resourceValidator());
+				referenceConfig.referenceCleaner(), referenceConfig.referenceExtractor(),
+				daoConfig.activityDefinitionDao(), helperConfig.exceptionHandler(), helperConfig.parameterConverter(),
+				authorizationConfig.activityDefinitionAuthorizationRule(), validationConfig.resourceValidator());
 	}
 
 	private ActivityDefinitionServiceImpl activityDefinitionServiceImpl()
@@ -196,9 +196,10 @@ public class WebserviceConfig
 	private BinaryServiceSecure binaryServiceSecure()
 	{
 		return new BinaryServiceSecure(binaryServiceImpl(), serverBase, helperConfig.responseGenerator(),
-				referenceConfig.referenceResolver(), referenceConfig.referenceCleaner(), daoConfig.binaryDao(),
-				helperConfig.exceptionHandler(), helperConfig.parameterConverter(),
-				authorizationConfig.binaryAuthorizationRule(), validationConfig.resourceValidator());
+				referenceConfig.referenceResolver(), referenceConfig.referenceCleaner(),
+				referenceConfig.referenceExtractor(), daoConfig.binaryDao(), helperConfig.exceptionHandler(),
+				helperConfig.parameterConverter(), authorizationConfig.binaryAuthorizationRule(),
+				validationConfig.resourceValidator());
 	}
 
 	private BinaryService binaryServiceImpl()
@@ -220,9 +221,10 @@ public class WebserviceConfig
 	private BundleServiceSecure bundleServiceSecure()
 	{
 		return new BundleServiceSecure(bundleServiceImpl(), serverBase, helperConfig.responseGenerator(),
-				referenceConfig.referenceResolver(), referenceConfig.referenceCleaner(), daoConfig.bundleDao(),
-				helperConfig.exceptionHandler(), helperConfig.parameterConverter(),
-				authorizationConfig.bundleAuthorizationRule(), validationConfig.resourceValidator());
+				referenceConfig.referenceResolver(), referenceConfig.referenceCleaner(),
+				referenceConfig.referenceExtractor(), daoConfig.bundleDao(), helperConfig.exceptionHandler(),
+				helperConfig.parameterConverter(), authorizationConfig.bundleAuthorizationRule(),
+				validationConfig.resourceValidator());
 	}
 
 	private BundleService bundleServiceImpl()
@@ -244,9 +246,10 @@ public class WebserviceConfig
 	private CodeSystemServiceSecure codeSystemServiceSecure()
 	{
 		return new CodeSystemServiceSecure(codeSystemServiceImpl(), serverBase, helperConfig.responseGenerator(),
-				referenceConfig.referenceResolver(), referenceConfig.referenceCleaner(), daoConfig.codeSystemDao(),
-				helperConfig.exceptionHandler(), helperConfig.parameterConverter(),
-				authorizationConfig.codeSystemAuthorizationRule(), validationConfig.resourceValidator());
+				referenceConfig.referenceResolver(), referenceConfig.referenceCleaner(),
+				referenceConfig.referenceExtractor(), daoConfig.codeSystemDao(), helperConfig.exceptionHandler(),
+				helperConfig.parameterConverter(), authorizationConfig.codeSystemAuthorizationRule(),
+				validationConfig.resourceValidator());
 	}
 
 	private CodeSystemServiceImpl codeSystemServiceImpl()
@@ -268,9 +271,10 @@ public class WebserviceConfig
 	private EndpointServiceSecure endpointServiceSecure()
 	{
 		return new EndpointServiceSecure(endpointServiceImpl(), serverBase, helperConfig.responseGenerator(),
-				referenceConfig.referenceResolver(), referenceConfig.referenceCleaner(), daoConfig.endpointDao(),
-				helperConfig.exceptionHandler(), helperConfig.parameterConverter(),
-				authorizationConfig.endpointAuthorizationRule(), validationConfig.resourceValidator());
+				referenceConfig.referenceResolver(), referenceConfig.referenceCleaner(),
+				referenceConfig.referenceExtractor(), daoConfig.endpointDao(), helperConfig.exceptionHandler(),
+				helperConfig.parameterConverter(), authorizationConfig.endpointAuthorizationRule(),
+				validationConfig.resourceValidator());
 	}
 
 	private EndpointServiceImpl endpointServiceImpl()
@@ -292,9 +296,10 @@ public class WebserviceConfig
 	private GroupServiceSecure groupServiceSecure()
 	{
 		return new GroupServiceSecure(groupServiceImpl(), serverBase, helperConfig.responseGenerator(),
-				referenceConfig.referenceResolver(), referenceConfig.referenceCleaner(), daoConfig.groupDao(),
-				helperConfig.exceptionHandler(), helperConfig.parameterConverter(),
-				authorizationConfig.groupAuthorizationRule(), validationConfig.resourceValidator());
+				referenceConfig.referenceResolver(), referenceConfig.referenceCleaner(),
+				referenceConfig.referenceExtractor(), daoConfig.groupDao(), helperConfig.exceptionHandler(),
+				helperConfig.parameterConverter(), authorizationConfig.groupAuthorizationRule(),
+				validationConfig.resourceValidator());
 	}
 
 	private GroupServiceImpl groupServiceImpl()
@@ -317,9 +322,9 @@ public class WebserviceConfig
 	{
 		return new HealthcareServiceServiceSecure(healthcareServiceServiceImpl(), serverBase,
 				helperConfig.responseGenerator(), referenceConfig.referenceResolver(),
-				referenceConfig.referenceCleaner(), daoConfig.healthcareServiceDao(), helperConfig.exceptionHandler(),
-				helperConfig.parameterConverter(), authorizationConfig.healthcareServiceAuthorizationRule(),
-				validationConfig.resourceValidator());
+				referenceConfig.referenceCleaner(), referenceConfig.referenceExtractor(),
+				daoConfig.healthcareServiceDao(), helperConfig.exceptionHandler(), helperConfig.parameterConverter(),
+				authorizationConfig.healthcareServiceAuthorizationRule(), validationConfig.resourceValidator());
 	}
 
 	private HealthcareServiceServiceImpl healthcareServiceServiceImpl()
@@ -341,9 +346,10 @@ public class WebserviceConfig
 	private LibraryServiceSecure libraryServiceSecure()
 	{
 		return new LibraryServiceSecure(libraryServiceImpl(), serverBase, helperConfig.responseGenerator(),
-				referenceConfig.referenceResolver(), referenceConfig.referenceCleaner(), daoConfig.libraryDao(),
-				helperConfig.exceptionHandler(), helperConfig.parameterConverter(),
-				authorizationConfig.libraryAuthorizationRule(), validationConfig.resourceValidator());
+				referenceConfig.referenceResolver(), referenceConfig.referenceCleaner(),
+				referenceConfig.referenceExtractor(), daoConfig.libraryDao(), helperConfig.exceptionHandler(),
+				helperConfig.parameterConverter(), authorizationConfig.libraryAuthorizationRule(),
+				validationConfig.resourceValidator());
 	}
 
 	private LibraryServiceImpl libraryServiceImpl()
@@ -365,9 +371,10 @@ public class WebserviceConfig
 	private LocationServiceSecure locationServiceSecure()
 	{
 		return new LocationServiceSecure(locationServiceImpl(), serverBase, helperConfig.responseGenerator(),
-				referenceConfig.referenceResolver(), referenceConfig.referenceCleaner(), daoConfig.locationDao(),
-				helperConfig.exceptionHandler(), helperConfig.parameterConverter(),
-				authorizationConfig.locationAuthorizationRule(), validationConfig.resourceValidator());
+				referenceConfig.referenceResolver(), referenceConfig.referenceCleaner(),
+				referenceConfig.referenceExtractor(), daoConfig.locationDao(), helperConfig.exceptionHandler(),
+				helperConfig.parameterConverter(), authorizationConfig.locationAuthorizationRule(),
+				validationConfig.resourceValidator());
 	}
 
 	private LocationServiceImpl locationServiceImpl()
@@ -389,9 +396,10 @@ public class WebserviceConfig
 	private MeasureServiceSecure measureServiceSecure()
 	{
 		return new MeasureServiceSecure(measureServiceImpl(), serverBase, helperConfig.responseGenerator(),
-				referenceConfig.referenceResolver(), referenceConfig.referenceCleaner(), daoConfig.measureDao(),
-				helperConfig.exceptionHandler(), helperConfig.parameterConverter(),
-				authorizationConfig.measureAuthorizationRule(), validationConfig.resourceValidator());
+				referenceConfig.referenceResolver(), referenceConfig.referenceCleaner(),
+				referenceConfig.referenceExtractor(), daoConfig.measureDao(), helperConfig.exceptionHandler(),
+				helperConfig.parameterConverter(), authorizationConfig.measureAuthorizationRule(),
+				validationConfig.resourceValidator());
 	}
 
 	private MeasureServiceImpl measureServiceImpl()
@@ -413,9 +421,10 @@ public class WebserviceConfig
 	private MeasureReportServiceSecure measureReportServiceSecure()
 	{
 		return new MeasureReportServiceSecure(measureReportServiceImpl(), serverBase, helperConfig.responseGenerator(),
-				referenceConfig.referenceResolver(), referenceConfig.referenceCleaner(), daoConfig.measureReportDao(),
-				helperConfig.exceptionHandler(), helperConfig.parameterConverter(),
-				authorizationConfig.measureReportAuthorizationRule(), validationConfig.resourceValidator());
+				referenceConfig.referenceResolver(), referenceConfig.referenceCleaner(),
+				referenceConfig.referenceExtractor(), daoConfig.measureReportDao(), helperConfig.exceptionHandler(),
+				helperConfig.parameterConverter(), authorizationConfig.measureReportAuthorizationRule(),
+				validationConfig.resourceValidator());
 	}
 
 	private MeasureReportServiceImpl measureReportServiceImpl()
@@ -437,9 +446,10 @@ public class WebserviceConfig
 	private NamingSystemServiceSecure namingSystemServiceSecure()
 	{
 		return new NamingSystemServiceSecure(namingSystemServiceImpl(), serverBase, helperConfig.responseGenerator(),
-				referenceConfig.referenceResolver(), referenceConfig.referenceCleaner(), daoConfig.namingSystemDao(),
-				helperConfig.exceptionHandler(), helperConfig.parameterConverter(),
-				authorizationConfig.namingSystemAuthorizationRule(), validationConfig.resourceValidator());
+				referenceConfig.referenceResolver(), referenceConfig.referenceCleaner(),
+				referenceConfig.referenceExtractor(), daoConfig.namingSystemDao(), helperConfig.exceptionHandler(),
+				helperConfig.parameterConverter(), authorizationConfig.namingSystemAuthorizationRule(),
+				validationConfig.resourceValidator());
 	}
 
 	private NamingSystemService namingSystemServiceImpl()
@@ -461,9 +471,10 @@ public class WebserviceConfig
 	private OrganizationServiceSecure organizationServiceSecure()
 	{
 		return new OrganizationServiceSecure(organizationServiceImpl(), serverBase, helperConfig.responseGenerator(),
-				referenceConfig.referenceResolver(), referenceConfig.referenceCleaner(), daoConfig.organizationDao(),
-				helperConfig.exceptionHandler(), helperConfig.parameterConverter(),
-				authorizationConfig.organizationAuthorizationRule(), validationConfig.resourceValidator());
+				referenceConfig.referenceResolver(), referenceConfig.referenceCleaner(),
+				referenceConfig.referenceExtractor(), daoConfig.organizationDao(), helperConfig.exceptionHandler(),
+				helperConfig.parameterConverter(), authorizationConfig.organizationAuthorizationRule(),
+				validationConfig.resourceValidator());
 	}
 
 	private OrganizationServiceImpl organizationServiceImpl()
@@ -486,9 +497,10 @@ public class WebserviceConfig
 	{
 		return new OrganizationAffiliationServiceSecure(organizationAffiliationServiceImpl(), serverBase,
 				helperConfig.responseGenerator(), referenceConfig.referenceResolver(),
-				referenceConfig.referenceCleaner(), daoConfig.organizationAffiliationDao(),
-				helperConfig.exceptionHandler(), helperConfig.parameterConverter(),
-				authorizationConfig.organizationAffiliationAuthorizationRule(), validationConfig.resourceValidator());
+				referenceConfig.referenceCleaner(), referenceConfig.referenceExtractor(),
+				daoConfig.organizationAffiliationDao(), helperConfig.exceptionHandler(),
+				helperConfig.parameterConverter(), authorizationConfig.organizationAffiliationAuthorizationRule(),
+				validationConfig.resourceValidator());
 	}
 
 	private OrganizationAffiliationServiceImpl organizationAffiliationServiceImpl()
@@ -511,9 +523,10 @@ public class WebserviceConfig
 	private PatientServiceSecure patientServiceSecure()
 	{
 		return new PatientServiceSecure(patientServiceImpl(), serverBase, helperConfig.responseGenerator(),
-				referenceConfig.referenceResolver(), referenceConfig.referenceCleaner(), daoConfig.patientDao(),
-				helperConfig.exceptionHandler(), helperConfig.parameterConverter(),
-				authorizationConfig.patientAuthorizationRule(), validationConfig.resourceValidator());
+				referenceConfig.referenceResolver(), referenceConfig.referenceCleaner(),
+				referenceConfig.referenceExtractor(), daoConfig.patientDao(), helperConfig.exceptionHandler(),
+				helperConfig.parameterConverter(), authorizationConfig.patientAuthorizationRule(),
+				validationConfig.resourceValidator());
 	}
 
 	private PatientServiceImpl patientServiceImpl()
@@ -536,9 +549,9 @@ public class WebserviceConfig
 	{
 		return new PractitionerRoleServiceSecure(practitionerRoleServiceImpl(), serverBase,
 				helperConfig.responseGenerator(), referenceConfig.referenceResolver(),
-				referenceConfig.referenceCleaner(), daoConfig.practitionerRoleDao(), helperConfig.exceptionHandler(),
-				helperConfig.parameterConverter(), authorizationConfig.practitionerRoleAuthorizationRule(),
-				validationConfig.resourceValidator());
+				referenceConfig.referenceCleaner(), referenceConfig.referenceExtractor(),
+				daoConfig.practitionerRoleDao(), helperConfig.exceptionHandler(), helperConfig.parameterConverter(),
+				authorizationConfig.practitionerRoleAuthorizationRule(), validationConfig.resourceValidator());
 	}
 
 	private PractitionerRoleServiceImpl practitionerRoleServiceImpl()
@@ -560,9 +573,10 @@ public class WebserviceConfig
 	private PractitionerServiceSecure practitionerServiceSecure()
 	{
 		return new PractitionerServiceSecure(practitionerServiceImpl(), serverBase, helperConfig.responseGenerator(),
-				referenceConfig.referenceResolver(), referenceConfig.referenceCleaner(), daoConfig.practitionerDao(),
-				helperConfig.exceptionHandler(), helperConfig.parameterConverter(),
-				authorizationConfig.practitionerAuthorizationRule(), validationConfig.resourceValidator());
+				referenceConfig.referenceResolver(), referenceConfig.referenceCleaner(),
+				referenceConfig.referenceExtractor(), daoConfig.practitionerDao(), helperConfig.exceptionHandler(),
+				helperConfig.parameterConverter(), authorizationConfig.practitionerAuthorizationRule(),
+				validationConfig.resourceValidator());
 	}
 
 	private PractitionerServiceImpl practitionerServiceImpl()
@@ -584,9 +598,10 @@ public class WebserviceConfig
 	private ProvenanceServiceSecure provenanceServiceSecure()
 	{
 		return new ProvenanceServiceSecure(provenanceServiceImpl(), serverBase, helperConfig.responseGenerator(),
-				referenceConfig.referenceResolver(), referenceConfig.referenceCleaner(), daoConfig.provenanceDao(),
-				helperConfig.exceptionHandler(), helperConfig.parameterConverter(),
-				authorizationConfig.provenanceAuthorizationRule(), validationConfig.resourceValidator());
+				referenceConfig.referenceResolver(), referenceConfig.referenceCleaner(),
+				referenceConfig.referenceExtractor(), daoConfig.provenanceDao(), helperConfig.exceptionHandler(),
+				helperConfig.parameterConverter(), authorizationConfig.provenanceAuthorizationRule(),
+				validationConfig.resourceValidator());
 	}
 
 	private ProvenanceServiceImpl provenanceServiceImpl()
@@ -608,9 +623,10 @@ public class WebserviceConfig
 	private ResearchStudyServiceSecure researchStudyServiceSecure()
 	{
 		return new ResearchStudyServiceSecure(researchStudyServiceImpl(), serverBase, helperConfig.responseGenerator(),
-				referenceConfig.referenceResolver(), referenceConfig.referenceCleaner(), daoConfig.researchStudyDao(),
-				helperConfig.exceptionHandler(), helperConfig.parameterConverter(),
-				authorizationConfig.researchStudyAuthorizationRule(), validationConfig.resourceValidator());
+				referenceConfig.referenceResolver(), referenceConfig.referenceCleaner(),
+				referenceConfig.referenceExtractor(), daoConfig.researchStudyDao(), helperConfig.exceptionHandler(),
+				helperConfig.parameterConverter(), authorizationConfig.researchStudyAuthorizationRule(),
+				validationConfig.resourceValidator());
 	}
 
 	private ResearchStudyServiceImpl researchStudyServiceImpl()
@@ -633,9 +649,9 @@ public class WebserviceConfig
 	{
 		return new StructureDefinitionServiceSecure(structureDefinitionServiceImpl(), serverBase,
 				helperConfig.responseGenerator(), referenceConfig.referenceResolver(),
-				referenceConfig.referenceCleaner(), daoConfig.structureDefinitionDao(), helperConfig.exceptionHandler(),
-				helperConfig.parameterConverter(), authorizationConfig.structureDefinitionAuthorizationRule(),
-				validationConfig.resourceValidator());
+				referenceConfig.referenceCleaner(), referenceConfig.referenceExtractor(),
+				daoConfig.structureDefinitionDao(), helperConfig.exceptionHandler(), helperConfig.parameterConverter(),
+				authorizationConfig.structureDefinitionAuthorizationRule(), validationConfig.resourceValidator());
 	}
 
 	private StructureDefinitionServiceImpl structureDefinitionServiceImpl()
@@ -658,9 +674,10 @@ public class WebserviceConfig
 	private SubscriptionServiceSecure subscriptionServiceSecure()
 	{
 		return new SubscriptionServiceSecure(subscriptionServiceImpl(), serverBase, helperConfig.responseGenerator(),
-				referenceConfig.referenceResolver(), referenceConfig.referenceCleaner(), daoConfig.subscriptionDao(),
-				helperConfig.exceptionHandler(), helperConfig.parameterConverter(),
-				authorizationConfig.subscriptionAuthorizationRule(), validationConfig.resourceValidator());
+				referenceConfig.referenceResolver(), referenceConfig.referenceCleaner(),
+				referenceConfig.referenceExtractor(), daoConfig.subscriptionDao(), helperConfig.exceptionHandler(),
+				helperConfig.parameterConverter(), authorizationConfig.subscriptionAuthorizationRule(),
+				validationConfig.resourceValidator());
 	}
 
 	private SubscriptionServiceImpl subscriptionServiceImpl()
@@ -682,9 +699,10 @@ public class WebserviceConfig
 	private TaskServiceSecure taskServiceSecure()
 	{
 		return new TaskServiceSecure(taskServiceImpl(), serverBase, helperConfig.responseGenerator(),
-				referenceConfig.referenceResolver(), referenceConfig.referenceCleaner(), daoConfig.taskDao(),
-				helperConfig.exceptionHandler(), helperConfig.parameterConverter(),
-				authorizationConfig.taskAuthorizationRule(), validationConfig.resourceValidator());
+				referenceConfig.referenceResolver(), referenceConfig.referenceCleaner(),
+				referenceConfig.referenceExtractor(), daoConfig.taskDao(), helperConfig.exceptionHandler(),
+				helperConfig.parameterConverter(), authorizationConfig.taskAuthorizationRule(),
+				validationConfig.resourceValidator());
 	}
 
 	private TaskServiceImpl taskServiceImpl()
@@ -706,9 +724,10 @@ public class WebserviceConfig
 	private ValueSetServiceSecure valueSetServiceSecure()
 	{
 		return new ValueSetServiceSecure(valueSetServiceImpl(), serverBase, helperConfig.responseGenerator(),
-				referenceConfig.referenceResolver(), referenceConfig.referenceCleaner(), daoConfig.valueSetDao(),
-				helperConfig.exceptionHandler(), helperConfig.parameterConverter(),
-				authorizationConfig.valueSetAuthorizationRule(), validationConfig.resourceValidator());
+				referenceConfig.referenceResolver(), referenceConfig.referenceCleaner(),
+				referenceConfig.referenceExtractor(), daoConfig.valueSetDao(), helperConfig.exceptionHandler(),
+				helperConfig.parameterConverter(), authorizationConfig.valueSetAuthorizationRule(),
+				validationConfig.resourceValidator());
 	}
 
 	private ValueSetServiceImpl valueSetServiceImpl()

--- a/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/webservice/secure/AbstractResourceServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/webservice/secure/AbstractResourceServiceSecure.java
@@ -363,7 +363,7 @@ public abstract class AbstractResourceServiceSecure<D extends ResourceDao<R>, R 
 	private Response update(String id, R newResource, UriInfo uri, HttpHeaders headers, R oldResource)
 	{
 		resolveLiteralInternalRelatedArtifactUrls(newResource);
-		
+
 		Optional<String> reasonUpdateAllowed = authorizationRule.reasonUpdateAllowed(getCurrentUser(), oldResource,
 				newResource);
 

--- a/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/webservice/secure/ActivityDefinitionServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/webservice/secure/ActivityDefinitionServiceSecure.java
@@ -6,6 +6,7 @@ import org.highmed.dsf.fhir.help.ExceptionHandler;
 import org.highmed.dsf.fhir.help.ParameterConverter;
 import org.highmed.dsf.fhir.help.ResponseGenerator;
 import org.highmed.dsf.fhir.service.ReferenceCleaner;
+import org.highmed.dsf.fhir.service.ReferenceExtractor;
 import org.highmed.dsf.fhir.service.ReferenceResolver;
 import org.highmed.dsf.fhir.validation.ResourceValidator;
 import org.highmed.dsf.fhir.webservice.specification.ActivityDefinitionService;
@@ -17,11 +18,12 @@ public class ActivityDefinitionServiceSecure
 {
 	public ActivityDefinitionServiceSecure(ActivityDefinitionService delegate, String serverBase,
 			ResponseGenerator responseGenerator, ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner,
-			ActivityDefinitionDao activityDefinitionDao, ExceptionHandler exceptionHandler,
-			ParameterConverter parameterConverter, AuthorizationRule<ActivityDefinition> authorizationRule,
-			ResourceValidator resourceValidator)
+			ReferenceExtractor referenceExtractor, ActivityDefinitionDao activityDefinitionDao,
+			ExceptionHandler exceptionHandler, ParameterConverter parameterConverter,
+			AuthorizationRule<ActivityDefinition> authorizationRule, ResourceValidator resourceValidator)
 	{
-		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, ActivityDefinition.class,
-				activityDefinitionDao, exceptionHandler, parameterConverter, authorizationRule, resourceValidator);
+		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, referenceExtractor,
+				ActivityDefinition.class, activityDefinitionDao, exceptionHandler, parameterConverter,
+				authorizationRule, resourceValidator);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/webservice/secure/BinaryServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/webservice/secure/BinaryServiceSecure.java
@@ -12,6 +12,7 @@ import org.highmed.dsf.fhir.help.ExceptionHandler;
 import org.highmed.dsf.fhir.help.ParameterConverter;
 import org.highmed.dsf.fhir.help.ResponseGenerator;
 import org.highmed.dsf.fhir.service.ReferenceCleaner;
+import org.highmed.dsf.fhir.service.ReferenceExtractor;
 import org.highmed.dsf.fhir.service.ReferenceResolver;
 import org.highmed.dsf.fhir.validation.ResourceValidator;
 import org.highmed.dsf.fhir.webservice.specification.BinaryService;
@@ -21,12 +22,13 @@ public class BinaryServiceSecure extends AbstractResourceServiceSecure<BinaryDao
 		implements BinaryService
 {
 	public BinaryServiceSecure(BinaryService delegate, String serverBase, ResponseGenerator responseGenerator,
-			ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner, BinaryDao binaryDao,
-			ExceptionHandler exceptionHandler, ParameterConverter parameterConverter,
-			AuthorizationRule<Binary> authorizationRule, ResourceValidator resourceValidator)
+			ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner,
+			ReferenceExtractor referenceExtractor, BinaryDao binaryDao, ExceptionHandler exceptionHandler,
+			ParameterConverter parameterConverter, AuthorizationRule<Binary> authorizationRule,
+			ResourceValidator resourceValidator)
 	{
-		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, Binary.class, binaryDao,
-				exceptionHandler, parameterConverter, authorizationRule, resourceValidator);
+		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, referenceExtractor,
+				Binary.class, binaryDao, exceptionHandler, parameterConverter, authorizationRule, resourceValidator);
 	}
 
 	@Override

--- a/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/webservice/secure/BundleServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/webservice/secure/BundleServiceSecure.java
@@ -6,6 +6,7 @@ import org.highmed.dsf.fhir.help.ExceptionHandler;
 import org.highmed.dsf.fhir.help.ParameterConverter;
 import org.highmed.dsf.fhir.help.ResponseGenerator;
 import org.highmed.dsf.fhir.service.ReferenceCleaner;
+import org.highmed.dsf.fhir.service.ReferenceExtractor;
 import org.highmed.dsf.fhir.service.ReferenceResolver;
 import org.highmed.dsf.fhir.validation.ResourceValidator;
 import org.highmed.dsf.fhir.webservice.specification.BundleService;
@@ -15,11 +16,12 @@ public class BundleServiceSecure extends AbstractResourceServiceSecure<BundleDao
 		implements BundleService
 {
 	public BundleServiceSecure(BundleService delegate, String serverBase, ResponseGenerator responseGenerator,
-			ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner, BundleDao bundleDao,
-			ExceptionHandler exceptionHandler, ParameterConverter parameterConverter,
-			AuthorizationRule<Bundle> authorizationRule, ResourceValidator resourceValidator)
+			ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner,
+			ReferenceExtractor referenceExtractor, BundleDao bundleDao, ExceptionHandler exceptionHandler,
+			ParameterConverter parameterConverter, AuthorizationRule<Bundle> authorizationRule,
+			ResourceValidator resourceValidator)
 	{
-		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, Bundle.class, bundleDao,
-				exceptionHandler, parameterConverter, authorizationRule, resourceValidator);
+		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, referenceExtractor,
+				Bundle.class, bundleDao, exceptionHandler, parameterConverter, authorizationRule, resourceValidator);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/webservice/secure/CodeSystemServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/webservice/secure/CodeSystemServiceSecure.java
@@ -6,6 +6,7 @@ import org.highmed.dsf.fhir.help.ExceptionHandler;
 import org.highmed.dsf.fhir.help.ParameterConverter;
 import org.highmed.dsf.fhir.help.ResponseGenerator;
 import org.highmed.dsf.fhir.service.ReferenceCleaner;
+import org.highmed.dsf.fhir.service.ReferenceExtractor;
 import org.highmed.dsf.fhir.service.ReferenceResolver;
 import org.highmed.dsf.fhir.validation.ResourceValidator;
 import org.highmed.dsf.fhir.webservice.specification.CodeSystemService;
@@ -15,11 +16,13 @@ public class CodeSystemServiceSecure extends AbstractResourceServiceSecure<CodeS
 		implements CodeSystemService
 {
 	public CodeSystemServiceSecure(CodeSystemService delegate, String serverBase, ResponseGenerator responseGenerator,
-			ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner, CodeSystemDao codeSystemDao,
-			ExceptionHandler exceptionHandler, ParameterConverter parameterConverter,
-			AuthorizationRule<CodeSystem> authorizationRule, ResourceValidator resourceValidator)
+			ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner,
+			ReferenceExtractor referenceExtractor, CodeSystemDao codeSystemDao, ExceptionHandler exceptionHandler,
+			ParameterConverter parameterConverter, AuthorizationRule<CodeSystem> authorizationRule,
+			ResourceValidator resourceValidator)
 	{
-		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, CodeSystem.class,
-				codeSystemDao, exceptionHandler, parameterConverter, authorizationRule, resourceValidator);
+		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, referenceExtractor,
+				CodeSystem.class, codeSystemDao, exceptionHandler, parameterConverter, authorizationRule,
+				resourceValidator);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/webservice/secure/EndpointServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/webservice/secure/EndpointServiceSecure.java
@@ -6,6 +6,7 @@ import org.highmed.dsf.fhir.help.ExceptionHandler;
 import org.highmed.dsf.fhir.help.ParameterConverter;
 import org.highmed.dsf.fhir.help.ResponseGenerator;
 import org.highmed.dsf.fhir.service.ReferenceCleaner;
+import org.highmed.dsf.fhir.service.ReferenceExtractor;
 import org.highmed.dsf.fhir.service.ReferenceResolver;
 import org.highmed.dsf.fhir.validation.ResourceValidator;
 import org.highmed.dsf.fhir.webservice.specification.EndpointService;
@@ -15,11 +16,13 @@ public class EndpointServiceSecure extends AbstractResourceServiceSecure<Endpoin
 		implements EndpointService
 {
 	public EndpointServiceSecure(EndpointService delegate, String serverBase, ResponseGenerator responseGenerator,
-			ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner, EndpointDao endpointDao,
-			ExceptionHandler exceptionHandler, ParameterConverter parameterConverter,
-			AuthorizationRule<Endpoint> authorizationRule, ResourceValidator resourceValidator)
+			ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner,
+			ReferenceExtractor referenceExtractor, EndpointDao endpointDao, ExceptionHandler exceptionHandler,
+			ParameterConverter parameterConverter, AuthorizationRule<Endpoint> authorizationRule,
+			ResourceValidator resourceValidator)
 	{
-		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, Endpoint.class, endpointDao,
-				exceptionHandler, parameterConverter, authorizationRule, resourceValidator);
+		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, referenceExtractor,
+				Endpoint.class, endpointDao, exceptionHandler, parameterConverter, authorizationRule,
+				resourceValidator);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/webservice/secure/GroupServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/webservice/secure/GroupServiceSecure.java
@@ -6,6 +6,7 @@ import org.highmed.dsf.fhir.help.ExceptionHandler;
 import org.highmed.dsf.fhir.help.ParameterConverter;
 import org.highmed.dsf.fhir.help.ResponseGenerator;
 import org.highmed.dsf.fhir.service.ReferenceCleaner;
+import org.highmed.dsf.fhir.service.ReferenceExtractor;
 import org.highmed.dsf.fhir.service.ReferenceResolver;
 import org.highmed.dsf.fhir.validation.ResourceValidator;
 import org.highmed.dsf.fhir.webservice.specification.GroupService;
@@ -15,11 +16,12 @@ public class GroupServiceSecure extends AbstractResourceServiceSecure<GroupDao, 
 		implements GroupService
 {
 	public GroupServiceSecure(GroupService delegate, String serverBase, ResponseGenerator responseGenerator,
-			ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner, GroupDao groupDao,
-			ExceptionHandler exceptionHandler, ParameterConverter parameterConverter,
-			AuthorizationRule<Group> authorizationRule, ResourceValidator resourceValidator)
+			ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner,
+			ReferenceExtractor referenceExtractor, GroupDao groupDao, ExceptionHandler exceptionHandler,
+			ParameterConverter parameterConverter, AuthorizationRule<Group> authorizationRule,
+			ResourceValidator resourceValidator)
 	{
-		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, Group.class, groupDao,
-				exceptionHandler, parameterConverter, authorizationRule, resourceValidator);
+		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, referenceExtractor,
+				Group.class, groupDao, exceptionHandler, parameterConverter, authorizationRule, resourceValidator);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/webservice/secure/HealthcareServiceServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/webservice/secure/HealthcareServiceServiceSecure.java
@@ -6,6 +6,7 @@ import org.highmed.dsf.fhir.help.ExceptionHandler;
 import org.highmed.dsf.fhir.help.ParameterConverter;
 import org.highmed.dsf.fhir.help.ResponseGenerator;
 import org.highmed.dsf.fhir.service.ReferenceCleaner;
+import org.highmed.dsf.fhir.service.ReferenceExtractor;
 import org.highmed.dsf.fhir.service.ReferenceResolver;
 import org.highmed.dsf.fhir.validation.ResourceValidator;
 import org.highmed.dsf.fhir.webservice.specification.HealthcareServiceService;
@@ -17,11 +18,12 @@ public class HealthcareServiceServiceSecure
 {
 	public HealthcareServiceServiceSecure(HealthcareServiceService delegate, String serverBase,
 			ResponseGenerator responseGenerator, ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner,
-			HealthcareServiceDao healthcareServiceDao, ExceptionHandler exceptionHandler,
-			ParameterConverter parameterConverter, AuthorizationRule<HealthcareService> authorizationRule,
-			ResourceValidator resourceValidator)
+			ReferenceExtractor referenceExtractor, HealthcareServiceDao healthcareServiceDao,
+			ExceptionHandler exceptionHandler, ParameterConverter parameterConverter,
+			AuthorizationRule<HealthcareService> authorizationRule, ResourceValidator resourceValidator)
 	{
-		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, HealthcareService.class,
-				healthcareServiceDao, exceptionHandler, parameterConverter, authorizationRule, resourceValidator);
+		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, referenceExtractor,
+				HealthcareService.class, healthcareServiceDao, exceptionHandler, parameterConverter, authorizationRule,
+				resourceValidator);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/webservice/secure/LibraryServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/webservice/secure/LibraryServiceSecure.java
@@ -6,6 +6,7 @@ import org.highmed.dsf.fhir.help.ExceptionHandler;
 import org.highmed.dsf.fhir.help.ParameterConverter;
 import org.highmed.dsf.fhir.help.ResponseGenerator;
 import org.highmed.dsf.fhir.service.ReferenceCleaner;
+import org.highmed.dsf.fhir.service.ReferenceExtractor;
 import org.highmed.dsf.fhir.service.ReferenceResolver;
 import org.highmed.dsf.fhir.validation.ResourceValidator;
 import org.highmed.dsf.fhir.webservice.specification.LibraryService;
@@ -15,11 +16,12 @@ public class LibraryServiceSecure extends AbstractResourceServiceSecure<LibraryD
 		implements LibraryService
 {
 	public LibraryServiceSecure(LibraryService delegate, String serverBase, ResponseGenerator responseGenerator,
-			ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner, LibraryDao libraryDao,
-			ExceptionHandler exceptionHandler, ParameterConverter parameterConverter,
-			AuthorizationRule<Library> authorizationRule, ResourceValidator resourceValidator)
+			ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner,
+			ReferenceExtractor referenceExtractor, LibraryDao libraryDao, ExceptionHandler exceptionHandler,
+			ParameterConverter parameterConverter, AuthorizationRule<Library> authorizationRule,
+			ResourceValidator resourceValidator)
 	{
-		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, Library.class, libraryDao,
-				exceptionHandler, parameterConverter, authorizationRule, resourceValidator);
+		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, referenceExtractor,
+				Library.class, libraryDao, exceptionHandler, parameterConverter, authorizationRule, resourceValidator);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/webservice/secure/LocationServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/webservice/secure/LocationServiceSecure.java
@@ -6,6 +6,7 @@ import org.highmed.dsf.fhir.help.ExceptionHandler;
 import org.highmed.dsf.fhir.help.ParameterConverter;
 import org.highmed.dsf.fhir.help.ResponseGenerator;
 import org.highmed.dsf.fhir.service.ReferenceCleaner;
+import org.highmed.dsf.fhir.service.ReferenceExtractor;
 import org.highmed.dsf.fhir.service.ReferenceResolver;
 import org.highmed.dsf.fhir.validation.ResourceValidator;
 import org.highmed.dsf.fhir.webservice.specification.LocationService;
@@ -15,11 +16,13 @@ public class LocationServiceSecure extends AbstractResourceServiceSecure<Locatio
 		implements LocationService
 {
 	public LocationServiceSecure(LocationService delegate, String serverBase, ResponseGenerator responseGenerator,
-			ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner, LocationDao locationDao,
-			ExceptionHandler exceptionHandler, ParameterConverter parameterConverter,
-			AuthorizationRule<Location> authorizationRule, ResourceValidator resourceValidator)
+			ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner,
+			ReferenceExtractor referenceExtractor, LocationDao locationDao, ExceptionHandler exceptionHandler,
+			ParameterConverter parameterConverter, AuthorizationRule<Location> authorizationRule,
+			ResourceValidator resourceValidator)
 	{
-		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, Location.class, locationDao,
-				exceptionHandler, parameterConverter, authorizationRule, resourceValidator);
+		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, referenceExtractor,
+				Location.class, locationDao, exceptionHandler, parameterConverter, authorizationRule,
+				resourceValidator);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/webservice/secure/MeasureReportServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/webservice/secure/MeasureReportServiceSecure.java
@@ -6,6 +6,7 @@ import org.highmed.dsf.fhir.help.ExceptionHandler;
 import org.highmed.dsf.fhir.help.ParameterConverter;
 import org.highmed.dsf.fhir.help.ResponseGenerator;
 import org.highmed.dsf.fhir.service.ReferenceCleaner;
+import org.highmed.dsf.fhir.service.ReferenceExtractor;
 import org.highmed.dsf.fhir.service.ReferenceResolver;
 import org.highmed.dsf.fhir.validation.ResourceValidator;
 import org.highmed.dsf.fhir.webservice.specification.MeasureReportService;
@@ -17,10 +18,12 @@ public class MeasureReportServiceSecure
 {
 	public MeasureReportServiceSecure(MeasureReportService delegate, String serverBase,
 			ResponseGenerator responseGenerator, ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner,
-			MeasureReportDao measureReportDao, ExceptionHandler exceptionHandler, ParameterConverter parameterConverter,
-			AuthorizationRule<MeasureReport> authorizationRule, ResourceValidator resourceValidator)
+			ReferenceExtractor referenceExtractor, MeasureReportDao measureReportDao, ExceptionHandler exceptionHandler,
+			ParameterConverter parameterConverter, AuthorizationRule<MeasureReport> authorizationRule,
+			ResourceValidator resourceValidator)
 	{
-		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, MeasureReport.class,
-				measureReportDao, exceptionHandler, parameterConverter, authorizationRule, resourceValidator);
+		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, referenceExtractor,
+				MeasureReport.class, measureReportDao, exceptionHandler, parameterConverter, authorizationRule,
+				resourceValidator);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/webservice/secure/MeasureServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/webservice/secure/MeasureServiceSecure.java
@@ -6,6 +6,7 @@ import org.highmed.dsf.fhir.help.ExceptionHandler;
 import org.highmed.dsf.fhir.help.ParameterConverter;
 import org.highmed.dsf.fhir.help.ResponseGenerator;
 import org.highmed.dsf.fhir.service.ReferenceCleaner;
+import org.highmed.dsf.fhir.service.ReferenceExtractor;
 import org.highmed.dsf.fhir.service.ReferenceResolver;
 import org.highmed.dsf.fhir.validation.ResourceValidator;
 import org.highmed.dsf.fhir.webservice.specification.MeasureService;
@@ -15,11 +16,12 @@ public class MeasureServiceSecure extends AbstractResourceServiceSecure<MeasureD
 		implements MeasureService
 {
 	public MeasureServiceSecure(MeasureService delegate, String serverBase, ResponseGenerator responseGenerator,
-			ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner, MeasureDao measureDao,
-			ExceptionHandler exceptionHandler, ParameterConverter parameterConverter,
-			AuthorizationRule<Measure> authorizationRule, ResourceValidator resourceValidator)
+			ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner,
+			ReferenceExtractor referenceExtractor, MeasureDao measureDao, ExceptionHandler exceptionHandler,
+			ParameterConverter parameterConverter, AuthorizationRule<Measure> authorizationRule,
+			ResourceValidator resourceValidator)
 	{
-		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, Measure.class, measureDao,
-				exceptionHandler, parameterConverter, authorizationRule, resourceValidator);
+		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, referenceExtractor,
+				Measure.class, measureDao, exceptionHandler, parameterConverter, authorizationRule, resourceValidator);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/webservice/secure/NamingSystemServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/webservice/secure/NamingSystemServiceSecure.java
@@ -6,6 +6,7 @@ import org.highmed.dsf.fhir.help.ExceptionHandler;
 import org.highmed.dsf.fhir.help.ParameterConverter;
 import org.highmed.dsf.fhir.help.ResponseGenerator;
 import org.highmed.dsf.fhir.service.ReferenceCleaner;
+import org.highmed.dsf.fhir.service.ReferenceExtractor;
 import org.highmed.dsf.fhir.service.ReferenceResolver;
 import org.highmed.dsf.fhir.validation.ResourceValidator;
 import org.highmed.dsf.fhir.webservice.specification.NamingSystemService;
@@ -16,10 +17,12 @@ public class NamingSystemServiceSecure extends
 {
 	public NamingSystemServiceSecure(NamingSystemService delegate, String serverBase,
 			ResponseGenerator responseGenerator, ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner,
-			NamingSystemDao naminngSystemDao, ExceptionHandler exceptionHandler, ParameterConverter parameterConverter,
-			AuthorizationRule<NamingSystem> authorizationRule, ResourceValidator resourceValidator)
+			ReferenceExtractor referenceExtractor, NamingSystemDao naminngSystemDao, ExceptionHandler exceptionHandler,
+			ParameterConverter parameterConverter, AuthorizationRule<NamingSystem> authorizationRule,
+			ResourceValidator resourceValidator)
 	{
-		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, NamingSystem.class,
-				naminngSystemDao, exceptionHandler, parameterConverter, authorizationRule, resourceValidator);
+		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, referenceExtractor,
+				NamingSystem.class, naminngSystemDao, exceptionHandler, parameterConverter, authorizationRule,
+				resourceValidator);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/webservice/secure/OrganizationAffiliationServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/webservice/secure/OrganizationAffiliationServiceSecure.java
@@ -6,6 +6,7 @@ import org.highmed.dsf.fhir.help.ExceptionHandler;
 import org.highmed.dsf.fhir.help.ParameterConverter;
 import org.highmed.dsf.fhir.help.ResponseGenerator;
 import org.highmed.dsf.fhir.service.ReferenceCleaner;
+import org.highmed.dsf.fhir.service.ReferenceExtractor;
 import org.highmed.dsf.fhir.service.ReferenceResolver;
 import org.highmed.dsf.fhir.validation.ResourceValidator;
 import org.highmed.dsf.fhir.webservice.specification.OrganizationAffiliationService;
@@ -17,11 +18,11 @@ public class OrganizationAffiliationServiceSecure extends
 {
 	public OrganizationAffiliationServiceSecure(OrganizationAffiliationService delegate, String serverBase,
 			ResponseGenerator responseGenerator, ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner,
-			OrganizationAffiliationDao organizationDao, ExceptionHandler exceptionHandler,
-			ParameterConverter parameterConverter, AuthorizationRule<OrganizationAffiliation> authorizationRule,
-			ResourceValidator resourceValidator)
+			ReferenceExtractor referenceExtractor, OrganizationAffiliationDao organizationDao,
+			ExceptionHandler exceptionHandler, ParameterConverter parameterConverter,
+			AuthorizationRule<OrganizationAffiliation> authorizationRule, ResourceValidator resourceValidator)
 	{
-		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner,
+		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, referenceExtractor,
 				OrganizationAffiliation.class, organizationDao, exceptionHandler, parameterConverter, authorizationRule,
 				resourceValidator);
 	}

--- a/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/webservice/secure/OrganizationServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/webservice/secure/OrganizationServiceSecure.java
@@ -6,6 +6,7 @@ import org.highmed.dsf.fhir.help.ExceptionHandler;
 import org.highmed.dsf.fhir.help.ParameterConverter;
 import org.highmed.dsf.fhir.help.ResponseGenerator;
 import org.highmed.dsf.fhir.service.ReferenceCleaner;
+import org.highmed.dsf.fhir.service.ReferenceExtractor;
 import org.highmed.dsf.fhir.service.ReferenceResolver;
 import org.highmed.dsf.fhir.validation.ResourceValidator;
 import org.highmed.dsf.fhir.webservice.specification.OrganizationService;
@@ -16,10 +17,12 @@ public class OrganizationServiceSecure extends
 {
 	public OrganizationServiceSecure(OrganizationService delegate, String serverBase,
 			ResponseGenerator responseGenerator, ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner,
-			OrganizationDao organizationDao, ExceptionHandler exceptionHandler, ParameterConverter parameterConverter,
-			AuthorizationRule<Organization> authorizationRule, ResourceValidator resourceValidator)
+			ReferenceExtractor referenceExtractor, OrganizationDao organizationDao, ExceptionHandler exceptionHandler,
+			ParameterConverter parameterConverter, AuthorizationRule<Organization> authorizationRule,
+			ResourceValidator resourceValidator)
 	{
-		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, Organization.class,
-				organizationDao, exceptionHandler, parameterConverter, authorizationRule, resourceValidator);
+		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, referenceExtractor,
+				Organization.class, organizationDao, exceptionHandler, parameterConverter, authorizationRule,
+				resourceValidator);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/webservice/secure/PatientServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/webservice/secure/PatientServiceSecure.java
@@ -6,6 +6,7 @@ import org.highmed.dsf.fhir.help.ExceptionHandler;
 import org.highmed.dsf.fhir.help.ParameterConverter;
 import org.highmed.dsf.fhir.help.ResponseGenerator;
 import org.highmed.dsf.fhir.service.ReferenceCleaner;
+import org.highmed.dsf.fhir.service.ReferenceExtractor;
 import org.highmed.dsf.fhir.service.ReferenceResolver;
 import org.highmed.dsf.fhir.validation.ResourceValidator;
 import org.highmed.dsf.fhir.webservice.specification.PatientService;
@@ -15,11 +16,12 @@ public class PatientServiceSecure extends AbstractResourceServiceSecure<PatientD
 		implements PatientService
 {
 	public PatientServiceSecure(PatientService delegate, String serverBase, ResponseGenerator responseGenerator,
-			ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner, PatientDao patientDao,
-			ExceptionHandler exceptionHandler, ParameterConverter parameterConverter,
-			AuthorizationRule<Patient> authorizationRule, ResourceValidator resourceValidator)
+			ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner,
+			ReferenceExtractor referenceExtractor, PatientDao patientDao, ExceptionHandler exceptionHandler,
+			ParameterConverter parameterConverter, AuthorizationRule<Patient> authorizationRule,
+			ResourceValidator resourceValidator)
 	{
-		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, Patient.class, patientDao,
-				exceptionHandler, parameterConverter, authorizationRule, resourceValidator);
+		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, referenceExtractor,
+				Patient.class, patientDao, exceptionHandler, parameterConverter, authorizationRule, resourceValidator);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/webservice/secure/PractitionerRoleServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/webservice/secure/PractitionerRoleServiceSecure.java
@@ -6,6 +6,7 @@ import org.highmed.dsf.fhir.help.ExceptionHandler;
 import org.highmed.dsf.fhir.help.ParameterConverter;
 import org.highmed.dsf.fhir.help.ResponseGenerator;
 import org.highmed.dsf.fhir.service.ReferenceCleaner;
+import org.highmed.dsf.fhir.service.ReferenceExtractor;
 import org.highmed.dsf.fhir.service.ReferenceResolver;
 import org.highmed.dsf.fhir.validation.ResourceValidator;
 import org.highmed.dsf.fhir.webservice.specification.PractitionerRoleService;
@@ -17,11 +18,12 @@ public class PractitionerRoleServiceSecure
 {
 	public PractitionerRoleServiceSecure(PractitionerRoleService delegate, String serverBase,
 			ResponseGenerator responseGenerator, ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner,
-			PractitionerRoleDao practitionerRoleDao, ExceptionHandler exceptionHandler,
-			ParameterConverter parameterConverter, AuthorizationRule<PractitionerRole> authorizationRule,
-			ResourceValidator resourceValidator)
+			ReferenceExtractor referenceExtractor, PractitionerRoleDao practitionerRoleDao,
+			ExceptionHandler exceptionHandler, ParameterConverter parameterConverter,
+			AuthorizationRule<PractitionerRole> authorizationRule, ResourceValidator resourceValidator)
 	{
-		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, PractitionerRole.class,
-				practitionerRoleDao, exceptionHandler, parameterConverter, authorizationRule, resourceValidator);
+		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, referenceExtractor,
+				PractitionerRole.class, practitionerRoleDao, exceptionHandler, parameterConverter, authorizationRule,
+				resourceValidator);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/webservice/secure/PractitionerServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/webservice/secure/PractitionerServiceSecure.java
@@ -6,6 +6,7 @@ import org.highmed.dsf.fhir.help.ExceptionHandler;
 import org.highmed.dsf.fhir.help.ParameterConverter;
 import org.highmed.dsf.fhir.help.ResponseGenerator;
 import org.highmed.dsf.fhir.service.ReferenceCleaner;
+import org.highmed.dsf.fhir.service.ReferenceExtractor;
 import org.highmed.dsf.fhir.service.ReferenceResolver;
 import org.highmed.dsf.fhir.validation.ResourceValidator;
 import org.highmed.dsf.fhir.webservice.specification.PractitionerService;
@@ -16,10 +17,12 @@ public class PractitionerServiceSecure extends
 {
 	public PractitionerServiceSecure(PractitionerService delegate, String serverBase,
 			ResponseGenerator responseGenerator, ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner,
-			PractitionerDao practitionerDao, ExceptionHandler exceptionHandler, ParameterConverter parameterConverter,
-			AuthorizationRule<Practitioner> authorizationRule, ResourceValidator resourceValidator)
+			ReferenceExtractor referenceExtractor, PractitionerDao practitionerDao, ExceptionHandler exceptionHandler,
+			ParameterConverter parameterConverter, AuthorizationRule<Practitioner> authorizationRule,
+			ResourceValidator resourceValidator)
 	{
-		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, Practitioner.class,
-				practitionerDao, exceptionHandler, parameterConverter, authorizationRule, resourceValidator);
+		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, referenceExtractor,
+				Practitioner.class, practitionerDao, exceptionHandler, parameterConverter, authorizationRule,
+				resourceValidator);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/webservice/secure/ProvenanceServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/webservice/secure/ProvenanceServiceSecure.java
@@ -6,6 +6,7 @@ import org.highmed.dsf.fhir.help.ExceptionHandler;
 import org.highmed.dsf.fhir.help.ParameterConverter;
 import org.highmed.dsf.fhir.help.ResponseGenerator;
 import org.highmed.dsf.fhir.service.ReferenceCleaner;
+import org.highmed.dsf.fhir.service.ReferenceExtractor;
 import org.highmed.dsf.fhir.service.ReferenceResolver;
 import org.highmed.dsf.fhir.validation.ResourceValidator;
 import org.highmed.dsf.fhir.webservice.specification.ProvenanceService;
@@ -15,11 +16,13 @@ public class ProvenanceServiceSecure extends AbstractResourceServiceSecure<Prove
 		implements ProvenanceService
 {
 	public ProvenanceServiceSecure(ProvenanceService delegate, String serverBase, ResponseGenerator responseGenerator,
-			ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner, ProvenanceDao provenanceDao,
-			ExceptionHandler exceptionHandler, ParameterConverter parameterConverter,
-			AuthorizationRule<Provenance> authorizationRule, ResourceValidator resourceValidator)
+			ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner,
+			ReferenceExtractor referenceExtractor, ProvenanceDao provenanceDao, ExceptionHandler exceptionHandler,
+			ParameterConverter parameterConverter, AuthorizationRule<Provenance> authorizationRule,
+			ResourceValidator resourceValidator)
 	{
-		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, Provenance.class,
-				provenanceDao, exceptionHandler, parameterConverter, authorizationRule, resourceValidator);
+		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, referenceExtractor,
+				Provenance.class, provenanceDao, exceptionHandler, parameterConverter, authorizationRule,
+				resourceValidator);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/webservice/secure/ResearchStudyServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/webservice/secure/ResearchStudyServiceSecure.java
@@ -6,6 +6,7 @@ import org.highmed.dsf.fhir.help.ExceptionHandler;
 import org.highmed.dsf.fhir.help.ParameterConverter;
 import org.highmed.dsf.fhir.help.ResponseGenerator;
 import org.highmed.dsf.fhir.service.ReferenceCleaner;
+import org.highmed.dsf.fhir.service.ReferenceExtractor;
 import org.highmed.dsf.fhir.service.ReferenceResolver;
 import org.highmed.dsf.fhir.validation.ResourceValidator;
 import org.highmed.dsf.fhir.webservice.specification.ResearchStudyService;
@@ -17,10 +18,12 @@ public class ResearchStudyServiceSecure
 {
 	public ResearchStudyServiceSecure(ResearchStudyService delegate, String serverBase,
 			ResponseGenerator responseGenerator, ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner,
-			ResearchStudyDao researchStudyDao, ExceptionHandler exceptionHandler, ParameterConverter parameterConverter,
-			AuthorizationRule<ResearchStudy> authorizationRule, ResourceValidator resourceValidator)
+			ReferenceExtractor referenceExtractor, ResearchStudyDao researchStudyDao, ExceptionHandler exceptionHandler,
+			ParameterConverter parameterConverter, AuthorizationRule<ResearchStudy> authorizationRule,
+			ResourceValidator resourceValidator)
 	{
-		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, ResearchStudy.class,
-				researchStudyDao, exceptionHandler, parameterConverter, authorizationRule, resourceValidator);
+		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, referenceExtractor,
+				ResearchStudy.class, researchStudyDao, exceptionHandler, parameterConverter, authorizationRule,
+				resourceValidator);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/webservice/secure/StructureDefinitionServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/webservice/secure/StructureDefinitionServiceSecure.java
@@ -10,6 +10,7 @@ import org.highmed.dsf.fhir.help.ExceptionHandler;
 import org.highmed.dsf.fhir.help.ParameterConverter;
 import org.highmed.dsf.fhir.help.ResponseGenerator;
 import org.highmed.dsf.fhir.service.ReferenceCleaner;
+import org.highmed.dsf.fhir.service.ReferenceExtractor;
 import org.highmed.dsf.fhir.service.ReferenceResolver;
 import org.highmed.dsf.fhir.validation.ResourceValidator;
 import org.highmed.dsf.fhir.webservice.specification.StructureDefinitionService;
@@ -26,12 +27,13 @@ public class StructureDefinitionServiceSecure
 
 	public StructureDefinitionServiceSecure(StructureDefinitionService delegate, String serverBase,
 			ResponseGenerator responseGenerator, ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner,
-			StructureDefinitionDao structureDefinitionDao, ExceptionHandler exceptionHandler,
-			ParameterConverter parameterConverter, AuthorizationRule<StructureDefinition> authorizationRule,
-			ResourceValidator resourceValidator)
+			ReferenceExtractor referenceExtractor, StructureDefinitionDao structureDefinitionDao,
+			ExceptionHandler exceptionHandler, ParameterConverter parameterConverter,
+			AuthorizationRule<StructureDefinition> authorizationRule, ResourceValidator resourceValidator)
 	{
-		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, StructureDefinition.class,
-				structureDefinitionDao, exceptionHandler, parameterConverter, authorizationRule, resourceValidator);
+		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, referenceExtractor,
+				StructureDefinition.class, structureDefinitionDao, exceptionHandler, parameterConverter,
+				authorizationRule, resourceValidator);
 	}
 
 	@Override

--- a/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/webservice/secure/SubscriptionServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/webservice/secure/SubscriptionServiceSecure.java
@@ -6,6 +6,7 @@ import org.highmed.dsf.fhir.help.ExceptionHandler;
 import org.highmed.dsf.fhir.help.ParameterConverter;
 import org.highmed.dsf.fhir.help.ResponseGenerator;
 import org.highmed.dsf.fhir.service.ReferenceCleaner;
+import org.highmed.dsf.fhir.service.ReferenceExtractor;
 import org.highmed.dsf.fhir.service.ReferenceResolver;
 import org.highmed.dsf.fhir.validation.ResourceValidator;
 import org.highmed.dsf.fhir.webservice.specification.SubscriptionService;
@@ -16,10 +17,12 @@ public class SubscriptionServiceSecure extends
 {
 	public SubscriptionServiceSecure(SubscriptionService delegate, String serverBase,
 			ResponseGenerator responseGenerator, ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner,
-			SubscriptionDao subscriptionDao, ExceptionHandler exceptionHandler, ParameterConverter parameterConverter,
-			AuthorizationRule<Subscription> authorizationRule, ResourceValidator resourceValidator)
+			ReferenceExtractor referenceExtractor, SubscriptionDao subscriptionDao, ExceptionHandler exceptionHandler,
+			ParameterConverter parameterConverter, AuthorizationRule<Subscription> authorizationRule,
+			ResourceValidator resourceValidator)
 	{
-		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, Subscription.class,
-				subscriptionDao, exceptionHandler, parameterConverter, authorizationRule, resourceValidator);
+		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, referenceExtractor,
+				Subscription.class, subscriptionDao, exceptionHandler, parameterConverter, authorizationRule,
+				resourceValidator);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/webservice/secure/TaskServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/webservice/secure/TaskServiceSecure.java
@@ -6,6 +6,7 @@ import org.highmed.dsf.fhir.help.ExceptionHandler;
 import org.highmed.dsf.fhir.help.ParameterConverter;
 import org.highmed.dsf.fhir.help.ResponseGenerator;
 import org.highmed.dsf.fhir.service.ReferenceCleaner;
+import org.highmed.dsf.fhir.service.ReferenceExtractor;
 import org.highmed.dsf.fhir.service.ReferenceResolver;
 import org.highmed.dsf.fhir.validation.ResourceValidator;
 import org.highmed.dsf.fhir.webservice.specification.TaskService;
@@ -14,11 +15,12 @@ import org.hl7.fhir.r4.model.Task;
 public class TaskServiceSecure extends AbstractResourceServiceSecure<TaskDao, Task, TaskService> implements TaskService
 {
 	public TaskServiceSecure(TaskService delegate, String serverBase, ResponseGenerator responseGenerator,
-			ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner, TaskDao taskDao,
-			ExceptionHandler exceptionHandler, ParameterConverter parameterConverter,
-			AuthorizationRule<Task> authorizationRule, ResourceValidator resourceValidator)
+			ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner,
+			ReferenceExtractor referenceExtractor, TaskDao taskDao, ExceptionHandler exceptionHandler,
+			ParameterConverter parameterConverter, AuthorizationRule<Task> authorizationRule,
+			ResourceValidator resourceValidator)
 	{
-		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, Task.class, taskDao,
-				exceptionHandler, parameterConverter, authorizationRule, resourceValidator);
+		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, referenceExtractor,
+				Task.class, taskDao, exceptionHandler, parameterConverter, authorizationRule, resourceValidator);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/webservice/secure/ValueSetServiceSecure.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/webservice/secure/ValueSetServiceSecure.java
@@ -6,6 +6,7 @@ import org.highmed.dsf.fhir.help.ExceptionHandler;
 import org.highmed.dsf.fhir.help.ParameterConverter;
 import org.highmed.dsf.fhir.help.ResponseGenerator;
 import org.highmed.dsf.fhir.service.ReferenceCleaner;
+import org.highmed.dsf.fhir.service.ReferenceExtractor;
 import org.highmed.dsf.fhir.service.ReferenceResolver;
 import org.highmed.dsf.fhir.validation.ResourceValidator;
 import org.highmed.dsf.fhir.webservice.specification.ValueSetService;
@@ -15,11 +16,13 @@ public class ValueSetServiceSecure extends AbstractResourceServiceSecure<ValueSe
 		implements ValueSetService
 {
 	public ValueSetServiceSecure(ValueSetService delegate, String serverBase, ResponseGenerator responseGenerator,
-			ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner, ValueSetDao valueSetDao,
-			ExceptionHandler exceptionHandler, ParameterConverter parameterConverter,
-			AuthorizationRule<ValueSet> authorizationRule, ResourceValidator resourceValidator)
+			ReferenceResolver referenceResolver, ReferenceCleaner referenceCleaner,
+			ReferenceExtractor referenceExtractor, ValueSetDao valueSetDao, ExceptionHandler exceptionHandler,
+			ParameterConverter parameterConverter, AuthorizationRule<ValueSet> authorizationRule,
+			ResourceValidator resourceValidator)
 	{
-		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, ValueSet.class, valueSetDao,
-				exceptionHandler, parameterConverter, authorizationRule, resourceValidator);
+		super(delegate, serverBase, responseGenerator, referenceResolver, referenceCleaner, referenceExtractor,
+				ValueSet.class, valueSetDao, exceptionHandler, parameterConverter, authorizationRule,
+				resourceValidator);
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/test/java/org/highmed/dsf/fhir/dao/command/ResourceReferenceTest.java
+++ b/dsf-fhir/dsf-fhir-server/src/test/java/org/highmed/dsf/fhir/dao/command/ResourceReferenceTest.java
@@ -1,5 +1,6 @@
 package org.highmed.dsf.fhir.dao.command;
 
+import static org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType.DOCUMENTATION;
 import static org.junit.Assert.assertEquals;
 
 import java.util.UUID;
@@ -8,6 +9,7 @@ import org.highmed.dsf.fhir.service.ResourceReference;
 import org.highmed.dsf.fhir.service.ResourceReference.ReferenceType;
 import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.Reference;
+import org.hl7.fhir.r4.model.RelatedArtifact;
 import org.junit.Test;
 
 public class ResourceReferenceTest
@@ -105,5 +107,44 @@ public class ResourceReferenceTest
 		assertEquals(ReferenceType.UNKNOWN, r4.getType(serverBase));
 		assertEquals(ReferenceType.UNKNOWN, r5.getType(serverBase));
 		assertEquals(ReferenceType.UNKNOWN, r6.getType(serverBase));
+	}
+
+	@Test
+	public void testGetTypeRelatedArtefact() throws Exception
+	{
+		var r1 = new ResourceReference("Foo.bar",
+				new RelatedArtifact().setType(DOCUMENTATION).setUrl("urn:uuid:" + UUID.randomUUID().toString()));
+
+		var r2 = new ResourceReference("Foo.bar",
+				new RelatedArtifact().setType(DOCUMENTATION).setUrl("Binary?_id=" + UUID.randomUUID().toString()));
+
+		var r3 = new ResourceReference("Foo.bar",
+				new RelatedArtifact().setType(DOCUMENTATION).setUrl("Binary/" + UUID.randomUUID().toString()));
+		var r4 = new ResourceReference("Foo.bar", new RelatedArtifact().setType(DOCUMENTATION)
+				.setUrl(serverBase + "/Binary/" + UUID.randomUUID().toString()));
+
+		var r5 = new ResourceReference("Foo.bar", new RelatedArtifact().setType(DOCUMENTATION)
+				.setUrl("http://blub.com/fhir/Binary/" + UUID.randomUUID().toString()));
+		var r6 = new ResourceReference("Foo.bar", new RelatedArtifact().setType(DOCUMENTATION)
+				.setUrl("http://blub.com/fhir/Binary/" + UUID.randomUUID().toString() + "/_history/1"));
+
+		var r7 = new ResourceReference("Foo.bar", new RelatedArtifact().setType(DOCUMENTATION).setUrl(serverBase));
+		var r8 = new ResourceReference("Foo.bar", new RelatedArtifact().setType(DOCUMENTATION).setUrl("foo.bar"));
+		var r9 = new ResourceReference("Foo.bar",
+				new RelatedArtifact().setType(DOCUMENTATION).setUrl(UUID.randomUUID().toString()));
+
+		assertEquals(ReferenceType.RELATED_ARTEFACT_TEMPORARY_URL, r1.getType(serverBase));
+
+		assertEquals(ReferenceType.RELATED_ARTEFACT_CONDITIONAL_URL, r2.getType(serverBase));
+
+		assertEquals(ReferenceType.RELATED_ARTEFACT_LITERAL_INTERNAL_URL, r3.getType(serverBase));
+		assertEquals(ReferenceType.RELATED_ARTEFACT_LITERAL_INTERNAL_URL, r4.getType(serverBase));
+
+		assertEquals(ReferenceType.RELATED_ARTEFACT_LITERAL_EXTERNAL_URL, r5.getType(serverBase));
+		assertEquals(ReferenceType.RELATED_ARTEFACT_LITERAL_EXTERNAL_URL, r6.getType(serverBase));
+
+		assertEquals(ReferenceType.UNKNOWN, r7.getType(serverBase));
+		assertEquals(ReferenceType.UNKNOWN, r8.getType(serverBase));
+		assertEquals(ReferenceType.UNKNOWN, r9.getType(serverBase));
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/test/java/org/highmed/dsf/fhir/dao/command/ResourceReferenceTest.java
+++ b/dsf-fhir/dsf-fhir-server/src/test/java/org/highmed/dsf/fhir/dao/command/ResourceReferenceTest.java
@@ -143,8 +143,8 @@ public class ResourceReferenceTest
 		assertEquals(ReferenceType.RELATED_ARTEFACT_LITERAL_EXTERNAL_URL, r5.getType(serverBase));
 		assertEquals(ReferenceType.RELATED_ARTEFACT_LITERAL_EXTERNAL_URL, r6.getType(serverBase));
 
-		assertEquals(ReferenceType.UNKNOWN, r7.getType(serverBase));
-		assertEquals(ReferenceType.UNKNOWN, r8.getType(serverBase));
-		assertEquals(ReferenceType.UNKNOWN, r9.getType(serverBase));
+		assertEquals(ReferenceType.RELATED_ARTEFACT_UNKNOWN_URL, r7.getType(serverBase));
+		assertEquals(ReferenceType.RELATED_ARTEFACT_UNKNOWN_URL, r8.getType(serverBase));
+		assertEquals(ReferenceType.RELATED_ARTEFACT_UNKNOWN_URL, r9.getType(serverBase));
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/test/java/org/highmed/dsf/fhir/integration/AbstractIntegrationTest.java
+++ b/dsf-fhir/dsf-fhir-server/src/test/java/org/highmed/dsf/fhir/integration/AbstractIntegrationTest.java
@@ -9,6 +9,7 @@ import static de.rwh.utils.jetty.JettyServer.webInfJars;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -33,6 +34,8 @@ import java.util.UUID;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
+
+import javax.ws.rs.WebApplicationException;
 
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.dbcp2.BasicDataSource;
@@ -386,5 +389,18 @@ public abstract class AbstractIntegrationTest extends AbstractDbTest
 	protected static final ReadAccessHelper getReadAccessHelper()
 	{
 		return readAccessHelper;
+	}
+
+	protected static void expectForbidden(Runnable operation) throws Exception
+	{
+		try
+		{
+			operation.run();
+			fail("WebApplicationException expected");
+		}
+		catch (WebApplicationException e)
+		{
+			assertEquals(403, e.getResponse().getStatus());
+		}
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/test/java/org/highmed/dsf/fhir/integration/BinaryIntegrationTest.java
+++ b/dsf-fhir/dsf-fhir-server/src/test/java/org/highmed/dsf/fhir/integration/BinaryIntegrationTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -37,19 +36,6 @@ import org.junit.Test;
 
 public class BinaryIntegrationTest extends AbstractIntegrationTest
 {
-	private void expectForbidden(Runnable operation) throws Exception
-	{
-		try
-		{
-			operation.run();
-			fail("WebApplicationException expected");
-		}
-		catch (WebApplicationException e)
-		{
-			assertEquals(403, e.getResponse().getStatus());
-		}
-	}
-
 	@Test
 	public void testReadAllowedLocalUser() throws Exception
 	{

--- a/dsf-fhir/dsf-fhir-server/src/test/java/org/highmed/dsf/fhir/integration/ResearchStudyIntegrationTest.java
+++ b/dsf-fhir/dsf-fhir-server/src/test/java/org/highmed/dsf/fhir/integration/ResearchStudyIntegrationTest.java
@@ -272,8 +272,7 @@ public class ResearchStudyIntegrationTest extends AbstractIntegrationTest
 	}
 
 	@Test
-	public void testCreateViaBundleWithRelatedArtefactRelativeLiteralInternalUrlNonExisting()
-			throws Exception
+	public void testCreateViaBundleWithRelatedArtefactRelativeLiteralInternalUrlNonExisting() throws Exception
 	{
 		ResearchStudy researchStudy = getResearchStudy("Binary/" + UUID.randomUUID().toString());
 

--- a/dsf-fhir/dsf-fhir-server/src/test/java/org/highmed/dsf/fhir/integration/ResearchStudyIntegrationTest.java
+++ b/dsf-fhir/dsf-fhir-server/src/test/java/org/highmed/dsf/fhir/integration/ResearchStudyIntegrationTest.java
@@ -1,9 +1,6 @@
 package org.highmed.dsf.fhir.integration;
 
 import static junit.framework.TestCase.assertEquals;
-import static org.hl7.fhir.r4.model.Bundle.BundleType.TRANSACTION;
-import static org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType.DOCUMENTATION;
-import static org.hl7.fhir.r4.model.ResearchStudy.ResearchStudyStatus.ACTIVE;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -15,19 +12,22 @@ import org.highmed.dsf.fhir.dao.GroupDao;
 import org.highmed.dsf.fhir.dao.ResearchStudyDao;
 import org.hl7.fhir.r4.model.Binary;
 import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Bundle.BundleType;
+import org.hl7.fhir.r4.model.Bundle.HTTPVerb;
 import org.hl7.fhir.r4.model.CodeType;
 import org.hl7.fhir.r4.model.Group;
 import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.Reference;
+import org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType;
 import org.hl7.fhir.r4.model.ResearchStudy;
-import org.hl7.fhir.r4.model.ResourceType;
+import org.hl7.fhir.r4.model.ResearchStudy.ResearchStudyStatus;
 import org.junit.Test;
 
 public class ResearchStudyIntegrationTest extends AbstractIntegrationTest
 {
 	@Test
-	public void testSearchResearchStudyByGroupId() throws Exception
+	public void testSearchByGroupId() throws Exception
 	{
 		Group g = new Group();
 		readAccessHelper.addLocal(g);
@@ -51,7 +51,7 @@ public class ResearchStudyIntegrationTest extends AbstractIntegrationTest
 	}
 
 	@Test
-	public void testResearchStudyRelatedArtefactUnknownUrl() throws Exception
+	public void testCreateWithRelatedArtefactUnknownUrl() throws Exception
 	{
 		String url = "https://foo.bar";
 		ResearchStudy researchStudy = getResearchStudy(url);
@@ -67,25 +67,57 @@ public class ResearchStudyIntegrationTest extends AbstractIntegrationTest
 	}
 
 	@Test
-	public void testResearchStudyRelatedArtefactTemporaryUrlResolution() throws Exception
+	public void testCreateViaBundleWithRelatedArtefactUnknownUrl() throws Exception
+	{
+		String url = "https://foo.bar";
+		ResearchStudy researchStudy = getResearchStudy(url);
+
+		Bundle bundle = new Bundle().setType(BundleType.TRANSACTION);
+		bundle.addEntry().setFullUrl("urn:uuid:" + UUID.randomUUID().toString()).setResource(researchStudy).getRequest()
+				.setUrl("ResearchStudy").setMethod(HTTPVerb.POST);
+
+		Bundle resultBundle = getWebserviceClient().postBundle(bundle);
+
+		assertNotNull(resultBundle);
+		assertEquals(1, resultBundle.getEntry().size());
+		assertNotNull(resultBundle.getEntry().get(0));
+		assertNotNull(resultBundle.getEntry().get(0).getResource());
+		assertTrue(resultBundle.getEntry().get(0).getResource() instanceof ResearchStudy);
+
+		ResearchStudy researchStudyResult = (ResearchStudy) resultBundle.getEntry().get(0).getResource();
+
+		assertNotNull(researchStudyResult);
+		assertEquals(1, researchStudyResult.getRelatedArtifact().size());
+
+		String relatedArtifactResultUrl = researchStudyResult.getRelatedArtifact().get(0).getUrl();
+
+		assertEquals(url, relatedArtifactResultUrl);
+	}
+
+	@Test
+	public void testCreateViaBundleWithRelatedArtefactTemporaryUrl() throws Exception
 	{
 		String binaryUrl = "urn:uuid:" + UUID.randomUUID().toString();
 		Binary binary = getBinary();
 
 		ResearchStudy researchStudy = getResearchStudy(binaryUrl);
 
-		Bundle bundle = new Bundle().setType(TRANSACTION);
+		Bundle bundle = new Bundle().setType(BundleType.TRANSACTION);
 		bundle.addEntry().setFullUrl("urn:uuid:" + UUID.randomUUID().toString()).setResource(researchStudy).getRequest()
-				.setUrl("ResearchStudy").setMethod(Bundle.HTTPVerb.POST);
+				.setUrl("ResearchStudy").setMethod(HTTPVerb.POST);
 		bundle.addEntry().setFullUrl(binaryUrl).setResource(binary).getRequest().setUrl("Binary")
-				.setMethod(Bundle.HTTPVerb.POST);
+				.setMethod(HTTPVerb.POST);
 
 		Bundle resultBundle = getWebserviceClient().postBundle(bundle);
 
 		assertNotNull(resultBundle);
 		assertEquals(2, resultBundle.getEntry().size());
-		assertEquals(ResourceType.ResearchStudy, resultBundle.getEntry().get(0).getResource().getResourceType());
-		assertEquals(ResourceType.Binary, resultBundle.getEntry().get(1).getResource().getResourceType());
+		assertNotNull(resultBundle.getEntry().get(0));
+		assertNotNull(resultBundle.getEntry().get(0).getResource());
+		assertTrue(resultBundle.getEntry().get(0).getResource() instanceof ResearchStudy);
+		assertNotNull(resultBundle.getEntry().get(1));
+		assertNotNull(resultBundle.getEntry().get(1).getResource());
+		assertTrue(resultBundle.getEntry().get(1).getResource() instanceof Binary);
 
 		ResearchStudy researchStudyResult = (ResearchStudy) resultBundle.getEntry().get(0).getResource();
 		Binary binaryResult = (Binary) resultBundle.getEntry().get(1).getResource();
@@ -94,15 +126,15 @@ public class ResearchStudyIntegrationTest extends AbstractIntegrationTest
 
 		String relatedArtifactResultUrl = researchStudyResult.getRelatedArtifact().get(0).getUrl();
 		String binaryResultUrl = binaryResult.getIdElement()
-				.withServerBase(getWebserviceClient().getBaseUrl(), ResourceType.Binary.name()).toVersionless()
-				.getValue();
+				.withServerBase(getWebserviceClient().getBaseUrl(), binaryResult.getResourceType().name())
+				.toVersionless().getValue();
 
-		assertTrue(new IdType(relatedArtifactResultUrl).isAbsolute());
 		assertEquals(binaryResultUrl, relatedArtifactResultUrl);
+		assertTrue(new IdType(relatedArtifactResultUrl).isAbsolute());
 	}
 
 	@Test
-	public void testResearchStudyRelatedArtefactConditionalUrlResolution() throws Exception
+	public void testCreateViaBundleWithRelatedArtefactConditionalUrl() throws Exception
 	{
 		Binary binary = getBinary();
 		Binary binaryResult = getWebserviceClient().create(binary);
@@ -111,15 +143,17 @@ public class ResearchStudyIntegrationTest extends AbstractIntegrationTest
 
 		ResearchStudy researchStudy = getResearchStudy("Binary?_id=" + binaryResult.getIdElement().getIdPart());
 
-		Bundle bundle = new Bundle().setType(TRANSACTION);
+		Bundle bundle = new Bundle().setType(BundleType.TRANSACTION);
 		bundle.addEntry().setFullUrl("urn:uuid:" + UUID.randomUUID().toString()).setResource(researchStudy).getRequest()
-				.setUrl("ResearchStudy").setMethod(Bundle.HTTPVerb.POST);
+				.setUrl("ResearchStudy").setMethod(HTTPVerb.POST);
 
 		Bundle resultBundle = getWebserviceClient().postBundle(bundle);
 
 		assertNotNull(resultBundle);
 		assertEquals(1, resultBundle.getEntry().size());
-		assertEquals(ResourceType.ResearchStudy, resultBundle.getEntry().get(0).getResource().getResourceType());
+		assertNotNull(resultBundle.getEntry().get(0));
+		assertNotNull(resultBundle.getEntry().get(0).getResource());
+		assertTrue(resultBundle.getEntry().get(0).getResource() instanceof ResearchStudy);
 
 		ResearchStudy researchStudyResult = (ResearchStudy) resultBundle.getEntry().get(0).getResource();
 
@@ -127,15 +161,15 @@ public class ResearchStudyIntegrationTest extends AbstractIntegrationTest
 
 		String relatedArtifactResultUrl = researchStudyResult.getRelatedArtifact().get(0).getUrl();
 		String binaryResultUrl = binaryResult.getIdElement()
-				.withServerBase(getWebserviceClient().getBaseUrl(), ResourceType.Binary.name()).toVersionless()
-				.getValue();
+				.withServerBase(getWebserviceClient().getBaseUrl(), binaryResult.getResourceType().name())
+				.toVersionless().getValue();
 
-		assertTrue(new IdType(relatedArtifactResultUrl).isAbsolute());
 		assertEquals(binaryResultUrl, relatedArtifactResultUrl);
+		assertTrue(new IdType(relatedArtifactResultUrl).isAbsolute());
 	}
 
 	@Test
-	public void testResearchStudyRelatedArtefactLiteralInternalUrlResolution() throws Exception
+	public void testCreateViaBundleWithRelatedArtefactRelativeLiteralInternalUrl() throws Exception
 	{
 		Binary binary = getBinary();
 		Binary binaryResult = getWebserviceClient().create(binary);
@@ -144,31 +178,33 @@ public class ResearchStudyIntegrationTest extends AbstractIntegrationTest
 
 		ResearchStudy researchStudy = getResearchStudy(
 				binaryResult.getIdElement().toUnqualifiedVersionless().getValue());
-		Bundle bundle = new Bundle().setType(TRANSACTION);
+		Bundle bundle = new Bundle().setType(BundleType.TRANSACTION);
 		bundle.addEntry().setFullUrl("urn:uuid:" + UUID.randomUUID().toString()).setResource(researchStudy).getRequest()
-				.setUrl("ResearchStudy").setMethod(Bundle.HTTPVerb.POST);
+				.setUrl("ResearchStudy").setMethod(HTTPVerb.POST);
 
 		Bundle resultBundle = getWebserviceClient().postBundle(bundle);
 
 		assertNotNull(resultBundle);
 		assertEquals(1, resultBundle.getEntry().size());
-		assertEquals(ResourceType.ResearchStudy, resultBundle.getEntry().get(0).getResource().getResourceType());
+		assertNotNull(resultBundle.getEntry().get(0));
+		assertNotNull(resultBundle.getEntry().get(0).getResource());
+		assertTrue(resultBundle.getEntry().get(0).getResource() instanceof ResearchStudy);
 
 		ResearchStudy researchStudyResult = (ResearchStudy) resultBundle.getEntry().get(0).getResource();
 
 		assertEquals(1, researchStudyResult.getRelatedArtifact().size());
 
 		String relatedArtifactResultUrl = researchStudyResult.getRelatedArtifact().get(0).getUrl();
-		String binaryResultUrl = binaryResult.getIdElement()
-				.withServerBase(getWebserviceClient().getBaseUrl(), ResourceType.Binary.name()).toVersionless()
-				.getValue();
 
-		assertTrue(new IdType(relatedArtifactResultUrl).isAbsolute());
+		String binaryResultUrl = binaryResult.getIdElement()
+				.withServerBase(getWebserviceClient().getBaseUrl(), binaryResult.getResourceType().name())
+				.toVersionless().getValue();
 		assertEquals(binaryResultUrl, relatedArtifactResultUrl);
+		assertTrue(new IdType(relatedArtifactResultUrl).isAbsolute());
 	}
 
 	@Test
-	public void testResearchStudyRelatedArtefactLiteralInternalUrlResolution2() throws Exception
+	public void testCreateViaBundleWithRelatedArtefactAbsoluteLiteralInternalUrl() throws Exception
 	{
 		Binary binary = getBinary();
 		Binary binaryResult = getWebserviceClient().create(binary);
@@ -176,23 +212,94 @@ public class ResearchStudyIntegrationTest extends AbstractIntegrationTest
 		assertNotNull(binaryResult);
 
 		String binaryResultUrl = binaryResult.getIdElement()
-				.withServerBase(getWebserviceClient().getBaseUrl(), ResourceType.Binary.name()).toVersionless()
-				.getValue();
+				.withServerBase(getWebserviceClient().getBaseUrl(), binaryResult.getResourceType().name())
+				.toVersionless().getValue();
 
 		ResearchStudy researchStudy = getResearchStudy(binaryResultUrl);
 
-		Bundle bundle = new Bundle().setType(TRANSACTION);
+		Bundle bundle = new Bundle().setType(BundleType.TRANSACTION);
 		bundle.addEntry().setFullUrl("urn:uuid:" + UUID.randomUUID().toString()).setResource(researchStudy).getRequest()
-				.setUrl("ResearchStudy").setMethod(Bundle.HTTPVerb.POST);
+				.setUrl("ResearchStudy").setMethod(HTTPVerb.POST);
 
 		Bundle resultBundle = getWebserviceClient().postBundle(bundle);
 
 		assertNotNull(resultBundle);
 		assertEquals(1, resultBundle.getEntry().size());
-		assertEquals(ResourceType.ResearchStudy, resultBundle.getEntry().get(0).getResource().getResourceType());
+		assertNotNull(resultBundle.getEntry().get(0));
+		assertNotNull(resultBundle.getEntry().get(0).getResource());
+		assertTrue(resultBundle.getEntry().get(0).getResource() instanceof ResearchStudy);
 
 		ResearchStudy researchStudyResult = (ResearchStudy) resultBundle.getEntry().get(0).getResource();
 
+		assertEquals(1, researchStudyResult.getRelatedArtifact().size());
+
+		String relatedArtifactResultUrl = researchStudyResult.getRelatedArtifact().get(0).getUrl();
+
+		assertEquals(binaryResultUrl, relatedArtifactResultUrl);
+		assertTrue(new IdType(relatedArtifactResultUrl).isAbsolute());
+	}
+
+	@Test
+	public void testCreateWithRelatedArtefactRelativeLiteralInternalUrl() throws Exception
+	{
+		Binary binary = getBinary();
+		Binary binaryResult = getWebserviceClient().create(binary);
+
+		assertNotNull(binaryResult);
+
+		ResearchStudy researchStudy = getResearchStudy(
+				binaryResult.getIdElement().toUnqualifiedVersionless().getValue());
+		ResearchStudy researchStudyResult = getWebserviceClient().create(researchStudy);
+
+		assertNotNull(researchStudyResult);
+		assertEquals(1, researchStudyResult.getRelatedArtifact().size());
+
+		String relatedArtifactResultUrl = researchStudyResult.getRelatedArtifact().get(0).getUrl();
+		String binaryResultUrl = binaryResult.getIdElement()
+				.withServerBase(getWebserviceClient().getBaseUrl(), binaryResult.getResourceType().name())
+				.toVersionless().getValue();
+
+		assertEquals(binaryResultUrl, relatedArtifactResultUrl);
+		assertTrue(new IdType(relatedArtifactResultUrl).isAbsolute());
+	}
+
+	@Test
+	public void testCreateWithRelatedArtefactRelativeLiteralInternalUrlNonExisting() throws Exception
+	{
+		ResearchStudy researchStudy = getResearchStudy("Binary/" + UUID.randomUUID().toString());
+
+		expectForbidden(() -> getWebserviceClient().create(researchStudy));
+	}
+
+	@Test
+	public void testCreateViaBundleWithRelatedArtefactRelativeLiteralInternalUrlNonExisting()
+			throws Exception
+	{
+		ResearchStudy researchStudy = getResearchStudy("Binary/" + UUID.randomUUID().toString());
+
+		Bundle bundle = new Bundle().setType(BundleType.TRANSACTION);
+		bundle.addEntry().setFullUrl("urn:uuid:" + UUID.randomUUID().toString()).setResource(researchStudy).getRequest()
+				.setUrl("ResearchStudy").setMethod(HTTPVerb.POST);
+
+		expectForbidden(() -> getWebserviceClient().postBundle(bundle));
+	}
+
+	@Test
+	public void testCreateWithRelatedArtefactAbsoluteLiteralInternalUrl() throws Exception
+	{
+		Binary binary = getBinary();
+		Binary binaryResult = getWebserviceClient().create(binary);
+
+		assertNotNull(binaryResult);
+
+		String binaryResultUrl = binaryResult.getIdElement()
+				.withServerBase(getWebserviceClient().getBaseUrl(), binaryResult.getResourceType().name())
+				.toVersionless().getValue();
+
+		ResearchStudy researchStudy = getResearchStudy(binaryResultUrl);
+		ResearchStudy researchStudyResult = getWebserviceClient().create(researchStudy);
+
+		assertNotNull(researchStudyResult);
 		assertEquals(1, researchStudyResult.getRelatedArtifact().size());
 
 		String relatedArtifactResultUrl = researchStudyResult.getRelatedArtifact().get(0).getUrl();
@@ -212,10 +319,10 @@ public class ResearchStudyIntegrationTest extends AbstractIntegrationTest
 	private ResearchStudy getResearchStudy(String url)
 	{
 		ResearchStudy researchStudy = new ResearchStudy();
-		researchStudy.setStatus(ACTIVE);
+		researchStudy.setStatus(ResearchStudyStatus.ACTIVE);
 		researchStudy.addIdentifier().setSystem("http://highmed.org/sid/research-study-identifier")
 				.setValue(UUID.randomUUID().toString());
-		researchStudy.addRelatedArtifact().setType(DOCUMENTATION).setUrl(url);
+		researchStudy.addRelatedArtifact().setType(RelatedArtifactType.DOCUMENTATION).setUrl(url);
 		researchStudy.addExtension().setUrl("http://highmed.org/fhir/StructureDefinition/extension-participating-ttp")
 				.setValue(new Reference().setType("Organization").setIdentifier(new Identifier()
 						.setSystem("http://highmed.org/sid/organization-identifier").setValue("Test_Organization")));

--- a/dsf-fhir/dsf-fhir-server/src/test/java/org/highmed/dsf/fhir/integration/ResearchStudyIntegrationTest.java
+++ b/dsf-fhir/dsf-fhir-server/src/test/java/org/highmed/dsf/fhir/integration/ResearchStudyIntegrationTest.java
@@ -1,16 +1,27 @@
 package org.highmed.dsf.fhir.integration;
 
 import static junit.framework.TestCase.assertEquals;
+import static org.hl7.fhir.r4.model.Bundle.BundleType.TRANSACTION;
+import static org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType.DOCUMENTATION;
+import static org.hl7.fhir.r4.model.ResearchStudy.ResearchStudyStatus.ACTIVE;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.UUID;
 
 import org.highmed.dsf.fhir.dao.GroupDao;
 import org.highmed.dsf.fhir.dao.ResearchStudyDao;
+import org.hl7.fhir.r4.model.Binary;
 import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.CodeType;
 import org.hl7.fhir.r4.model.Group;
+import org.hl7.fhir.r4.model.IdType;
+import org.hl7.fhir.r4.model.Identifier;
+import org.hl7.fhir.r4.model.Reference;
 import org.hl7.fhir.r4.model.ResearchStudy;
+import org.hl7.fhir.r4.model.ResourceType;
 import org.junit.Test;
 
 public class ResearchStudyIntegrationTest extends AbstractIntegrationTest
@@ -37,5 +48,179 @@ public class ResearchStudyIntegrationTest extends AbstractIntegrationTest
 		assertNotNull(resultBundle.getEntryFirstRep());
 		assertNotNull(resultBundle.getEntryFirstRep().getResource());
 		assertEquals(researchStudyId, resultBundle.getEntryFirstRep().getResource().getIdElement().getIdPart());
+	}
+
+	@Test
+	public void testResearchStudyRelatedArtefactUnknownUrl() throws Exception
+	{
+		String url = "https://foo.bar";
+		ResearchStudy researchStudy = getResearchStudy(url);
+
+		ResearchStudy researchStudyResult = getWebserviceClient().create(researchStudy);
+
+		assertNotNull(researchStudyResult);
+		assertEquals(1, researchStudyResult.getRelatedArtifact().size());
+
+		String relatedArtifactResultUrl = researchStudyResult.getRelatedArtifact().get(0).getUrl();
+
+		assertEquals(url, relatedArtifactResultUrl);
+	}
+
+	@Test
+	public void testResearchStudyRelatedArtefactTemporaryUrlResolution() throws Exception
+	{
+		String binaryUrl = "urn:uuid:" + UUID.randomUUID().toString();
+		Binary binary = getBinary();
+
+		ResearchStudy researchStudy = getResearchStudy(binaryUrl);
+
+		Bundle bundle = new Bundle().setType(TRANSACTION);
+		bundle.addEntry().setFullUrl("urn:uuid:" + UUID.randomUUID().toString()).setResource(researchStudy).getRequest()
+				.setUrl("ResearchStudy").setMethod(Bundle.HTTPVerb.POST);
+		bundle.addEntry().setFullUrl(binaryUrl).setResource(binary).getRequest().setUrl("Binary")
+				.setMethod(Bundle.HTTPVerb.POST);
+
+		Bundle resultBundle = getWebserviceClient().postBundle(bundle);
+
+		assertNotNull(resultBundle);
+		assertEquals(2, resultBundle.getEntry().size());
+		assertEquals(ResourceType.ResearchStudy, resultBundle.getEntry().get(0).getResource().getResourceType());
+		assertEquals(ResourceType.Binary, resultBundle.getEntry().get(1).getResource().getResourceType());
+
+		ResearchStudy researchStudyResult = (ResearchStudy) resultBundle.getEntry().get(0).getResource();
+		Binary binaryResult = (Binary) resultBundle.getEntry().get(1).getResource();
+
+		assertEquals(1, researchStudyResult.getRelatedArtifact().size());
+
+		String relatedArtifactResultUrl = researchStudyResult.getRelatedArtifact().get(0).getUrl();
+		String binaryResultUrl = binaryResult.getIdElement()
+				.withServerBase(getWebserviceClient().getBaseUrl(), ResourceType.Binary.name()).toVersionless()
+				.getValue();
+
+		assertTrue(new IdType(relatedArtifactResultUrl).isAbsolute());
+		assertEquals(binaryResultUrl, relatedArtifactResultUrl);
+	}
+
+	@Test
+	public void testResearchStudyRelatedArtefactConditionalUrlResolution() throws Exception
+	{
+		Binary binary = getBinary();
+		Binary binaryResult = getWebserviceClient().create(binary);
+
+		assertNotNull(binaryResult);
+
+		ResearchStudy researchStudy = getResearchStudy("Binary?_id=" + binaryResult.getIdElement().getIdPart());
+
+		Bundle bundle = new Bundle().setType(TRANSACTION);
+		bundle.addEntry().setFullUrl("urn:uuid:" + UUID.randomUUID().toString()).setResource(researchStudy).getRequest()
+				.setUrl("ResearchStudy").setMethod(Bundle.HTTPVerb.POST);
+
+		Bundle resultBundle = getWebserviceClient().postBundle(bundle);
+
+		assertNotNull(resultBundle);
+		assertEquals(1, resultBundle.getEntry().size());
+		assertEquals(ResourceType.ResearchStudy, resultBundle.getEntry().get(0).getResource().getResourceType());
+
+		ResearchStudy researchStudyResult = (ResearchStudy) resultBundle.getEntry().get(0).getResource();
+
+		assertEquals(1, researchStudyResult.getRelatedArtifact().size());
+
+		String relatedArtifactResultUrl = researchStudyResult.getRelatedArtifact().get(0).getUrl();
+		String binaryResultUrl = binaryResult.getIdElement()
+				.withServerBase(getWebserviceClient().getBaseUrl(), ResourceType.Binary.name()).toVersionless()
+				.getValue();
+
+		assertTrue(new IdType(relatedArtifactResultUrl).isAbsolute());
+		assertEquals(binaryResultUrl, relatedArtifactResultUrl);
+	}
+
+	@Test
+	public void testResearchStudyRelatedArtefactLiteralInternalUrlResolution() throws Exception
+	{
+		Binary binary = getBinary();
+		Binary binaryResult = getWebserviceClient().create(binary);
+
+		assertNotNull(binaryResult);
+
+		ResearchStudy researchStudy = getResearchStudy(
+				binaryResult.getIdElement().toUnqualifiedVersionless().getValue());
+		Bundle bundle = new Bundle().setType(TRANSACTION);
+		bundle.addEntry().setFullUrl("urn:uuid:" + UUID.randomUUID().toString()).setResource(researchStudy).getRequest()
+				.setUrl("ResearchStudy").setMethod(Bundle.HTTPVerb.POST);
+
+		Bundle resultBundle = getWebserviceClient().postBundle(bundle);
+
+		assertNotNull(resultBundle);
+		assertEquals(1, resultBundle.getEntry().size());
+		assertEquals(ResourceType.ResearchStudy, resultBundle.getEntry().get(0).getResource().getResourceType());
+
+		ResearchStudy researchStudyResult = (ResearchStudy) resultBundle.getEntry().get(0).getResource();
+
+		assertEquals(1, researchStudyResult.getRelatedArtifact().size());
+
+		String relatedArtifactResultUrl = researchStudyResult.getRelatedArtifact().get(0).getUrl();
+		String binaryResultUrl = binaryResult.getIdElement()
+				.withServerBase(getWebserviceClient().getBaseUrl(), ResourceType.Binary.name()).toVersionless()
+				.getValue();
+
+		assertTrue(new IdType(relatedArtifactResultUrl).isAbsolute());
+		assertEquals(binaryResultUrl, relatedArtifactResultUrl);
+	}
+
+	@Test
+	public void testResearchStudyRelatedArtefactLiteralInternalUrlResolution2() throws Exception
+	{
+		Binary binary = getBinary();
+		Binary binaryResult = getWebserviceClient().create(binary);
+
+		assertNotNull(binaryResult);
+
+		String binaryResultUrl = binaryResult.getIdElement()
+				.withServerBase(getWebserviceClient().getBaseUrl(), ResourceType.Binary.name()).toVersionless()
+				.getValue();
+
+		ResearchStudy researchStudy = getResearchStudy(binaryResultUrl);
+
+		Bundle bundle = new Bundle().setType(TRANSACTION);
+		bundle.addEntry().setFullUrl("urn:uuid:" + UUID.randomUUID().toString()).setResource(researchStudy).getRequest()
+				.setUrl("ResearchStudy").setMethod(Bundle.HTTPVerb.POST);
+
+		Bundle resultBundle = getWebserviceClient().postBundle(bundle);
+
+		assertNotNull(resultBundle);
+		assertEquals(1, resultBundle.getEntry().size());
+		assertEquals(ResourceType.ResearchStudy, resultBundle.getEntry().get(0).getResource().getResourceType());
+
+		ResearchStudy researchStudyResult = (ResearchStudy) resultBundle.getEntry().get(0).getResource();
+
+		assertEquals(1, researchStudyResult.getRelatedArtifact().size());
+
+		String relatedArtifactResultUrl = researchStudyResult.getRelatedArtifact().get(0).getUrl();
+
+		assertTrue(new IdType(relatedArtifactResultUrl).isAbsolute());
+		assertEquals(binaryResultUrl, relatedArtifactResultUrl);
+	}
+
+	private Binary getBinary()
+	{
+		Binary binary = new Binary(new CodeType("application/pdf"));
+		readAccessHelper.addLocal(binary);
+
+		return binary;
+	}
+
+	private ResearchStudy getResearchStudy(String url)
+	{
+		ResearchStudy researchStudy = new ResearchStudy();
+		researchStudy.setStatus(ACTIVE);
+		researchStudy.addIdentifier().setSystem("http://highmed.org/sid/research-study-identifier")
+				.setValue(UUID.randomUUID().toString());
+		researchStudy.addRelatedArtifact().setType(DOCUMENTATION).setUrl(url);
+		researchStudy.addExtension().setUrl("http://highmed.org/fhir/StructureDefinition/extension-participating-ttp")
+				.setValue(new Reference().setType("Organization").setIdentifier(new Identifier()
+						.setSystem("http://highmed.org/sid/organization-identifier").setValue("Test_Organization")));
+		readAccessHelper.addLocal(researchStudy);
+
+		return researchStudy;
 	}
 }


### PR DESCRIPTION
This PR adds the following properties to the field RelatesArtifact.url in Transaction-Bundles:

Temporary url references starting with urn:uuid: will be resolved to literal absolute references
Conditional url references will be resolved to literal absolute references
Literal internal url references will be resolved to literal absolute references
Literal external url references will be checked
All other "normal" url strings (i.e. with no FHIR context) will be treated as before.

closes #197 