### PR TITLE
issues/239 Ensure Valid Package Name as BPE Logger Names

### DIFF
--- a/dsf-bpe/dsf-bpe-server-jetty/docker/conf/log4j2.xml
+++ b/dsf-bpe/dsf-bpe-server-jetty/docker/conf/log4j2.xml
@@ -16,8 +16,8 @@
 	</Appenders>
 	<Loggers>
 		<Logger name="org.highmed" level="DEBUG" />
-		<Logger name="de.netzwerk-universitaetsmedizin" level="DEBUG" />
-		<Logger name="de.medizininformatik-initiative" level="DEBUG" />
+		<Logger name="de.netzwerk_universitaetsmedizin" level="DEBUG" />
+		<Logger name="de.medizininformatik_initiative" level="DEBUG" />
 		<Logger name="org.eclipse.jetty" level="INFO" />
 
 		<Root level="WARN">


### PR DESCRIPTION
Replaces `-` with `_` within pre-packaged BPE logger names to ensure they are valid Java package names.

Fixes #239 