### PR TITLE
test demonstrating- and fix for #247

### DIFF
--- a/dsf-fhir/dsf-fhir-server/src/test/java/org/highmed/dsf/fhir/integration/TaskIntegrationTest.java
+++ b/dsf-fhir/dsf-fhir-server/src/test/java/org/highmed/dsf/fhir/integration/TaskIntegrationTest.java
@@ -29,6 +29,7 @@ import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
 import org.hl7.fhir.r4.model.Bundle.BundleType;
 import org.hl7.fhir.r4.model.Bundle.HTTPVerb;
+import org.hl7.fhir.r4.model.CanonicalType;
 import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.Organization;
 import org.hl7.fhir.r4.model.Reference;
@@ -658,6 +659,47 @@ public class TaskIntegrationTest extends AbstractIntegrationTest
 		Task createdTask = getWebserviceClient().create(task);
 		assertNotNull(createdTask);
 		assertNotNull(createdTask.getIdElement().getIdPart());
+	}
+
+	@Test
+	public void testCreateTaskAllowedLocalUserVersionSpecificProfile() throws Exception
+	{
+		ActivityDefinition ad1 = readActivityDefinition("highmed-test-activity-definition1-0.5.0.xml");
+		ActivityDefinition createdAd1 = getWebserviceClient().create(ad1);
+		assertNotNull(createdAd1);
+		assertNotNull(createdAd1.getIdElement().getIdPart());
+
+		StructureDefinition testTaskProfile = readTestTaskProfile();
+		StructureDefinition createdTestTaskProfile = getWebserviceClient().create(testTaskProfile);
+		assertNotNull(createdTestTaskProfile);
+		assertNotNull(createdTestTaskProfile.getIdElement().getIdPart());
+
+		Task task = readTestTask("Test_Organization", "Test_Organization");
+		CanonicalType profile = task.getMeta().getProfile().get(0);
+		profile.setValue(profile.getValue() + "|0.5.0");
+		Task createdTask = getWebserviceClient().create(task);
+		assertNotNull(createdTask);
+		assertNotNull(createdTask.getIdElement().getIdPart());
+	}
+
+	@Test
+	public void testCreateTaskAllowedLocalUserVersionSpecificProfileBadVersion() throws Exception
+	{
+		ActivityDefinition ad1 = readActivityDefinition("highmed-test-activity-definition1-0.5.0.xml");
+		ActivityDefinition createdAd1 = getWebserviceClient().create(ad1);
+		assertNotNull(createdAd1);
+		assertNotNull(createdAd1.getIdElement().getIdPart());
+
+		StructureDefinition testTaskProfile = readTestTaskProfile();
+		StructureDefinition createdTestTaskProfile = getWebserviceClient().create(testTaskProfile);
+		assertNotNull(createdTestTaskProfile);
+		assertNotNull(createdTestTaskProfile.getIdElement().getIdPart());
+
+		Task task = readTestTask("Test_Organization", "Test_Organization");
+		CanonicalType profile = task.getMeta().getProfile().get(0);
+		profile.setValue(profile.getValue() + "|0.x.0");
+
+		expectForbidden(() -> getWebserviceClient().create(task));
 	}
 
 	@Test

--- a/dsf-fhir/dsf-fhir-server/src/test/resources/integration/task/highmed-test-activity-definition1-0.5.0.xml
+++ b/dsf-fhir/dsf-fhir-server/src/test/resources/integration/task/highmed-test-activity-definition1-0.5.0.xml
@@ -10,7 +10,7 @@
 			<valueString value="test-message" />
 		</extension>
 		<extension url="task-profile">
-			<valueCanonical value="http://highmed.org/fhir/StructureDefinition/test-task" />
+			<valueCanonical value="http://highmed.org/fhir/StructureDefinition/test-task|0.5.0" />
 		</extension>
 		<extension url="requester">
 			<valueCoding>

--- a/dsf-fhir/dsf-fhir-server/src/test/resources/integration/task/highmed-test-activity-definition2-0.5.0.xml
+++ b/dsf-fhir/dsf-fhir-server/src/test/resources/integration/task/highmed-test-activity-definition2-0.5.0.xml
@@ -10,7 +10,7 @@
 			<valueString value="test-message" />
 		</extension>
 		<extension url="task-profile">
-			<valueCanonical value="http://highmed.org/fhir/StructureDefinition/test-task" />
+			<valueCanonical value="http://highmed.org/fhir/StructureDefinition/test-task|0.5.0" />
 		</extension>
 		<extension url="requester">
 			<valueCoding>

--- a/dsf-fhir/dsf-fhir-server/src/test/resources/integration/task/highmed-test-activity-definition3-0.5.0.xml
+++ b/dsf-fhir/dsf-fhir-server/src/test/resources/integration/task/highmed-test-activity-definition3-0.5.0.xml
@@ -11,7 +11,7 @@
 			<valueString value="test-message" />
 		</extension>
 		<extension url="task-profile">
-			<valueCanonical value="http://highmed.org/fhir/StructureDefinition/test-task" />
+			<valueCanonical value="http://highmed.org/fhir/StructureDefinition/test-task|0.5.0" />
 		</extension>
 		<extension url="requester">
 			<valueCoding>

--- a/dsf-fhir/dsf-fhir-server/src/test/resources/integration/task/highmed-test-activity-definition4-0.5.0.xml
+++ b/dsf-fhir/dsf-fhir-server/src/test/resources/integration/task/highmed-test-activity-definition4-0.5.0.xml
@@ -11,7 +11,7 @@
 			<valueString value="test-message" />
 		</extension>
 		<extension url="task-profile">
-			<valueCanonical value="http://highmed.org/fhir/StructureDefinition/test-task" />
+			<valueCanonical value="http://highmed.org/fhir/StructureDefinition/test-task|0.5.0" />
 		</extension>
 		<extension url="requester">
 			<valueCoding>


### PR DESCRIPTION
If the task profile is version specific within the ActivityDefinition, Tasks are excepted that declare the specific version of the profile, or the profile without version. If the task profile within the ActivityDefinition does not specify a version, Tasks with version specific profile declarations are not excepted.

fixes #247