### PR TITLE
added a warning log message to indicate that no resource where found

### DIFF
--- a/dsf-bpe/dsf-bpe-server/src/main/java/org/highmed/dsf/bpe/service/FhirResourceHandlerImpl.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/org/highmed/dsf/bpe/service/FhirResourceHandlerImpl.java
@@ -352,7 +352,14 @@ public class FhirResourceHandlerImpl implements FhirResourceHandler, Initializin
 		}
 		else
 		{
-			return dbResourcesByProcess.get(process).stream().map(info -> ProcessesResource.from(info).add(process));
+			List<ResourceInfo> resources = dbResourcesByProcess.get(process);
+			if (resources == null)
+			{
+				logger.warn("No resources found in BPE DB for process {}", process);
+				resources = Collections.emptyList();
+			}
+
+			return resources.stream().map(info -> ProcessesResource.from(info).add(process));
 		}
 	}
 


### PR DESCRIPTION
The NPE from #250 is most likely a result of an aborted BPE startup
between process deploy and FHIR resource upload.

fixes #250