### PR TITLE
Improve Docker Secrets Reader

### DIFF
--- a/dsf-tools/dsf-tools-docker-secrets-reader/src/main/java/org/highmed/dsf/tools/docker/secrets/DockerSecretsPropertySourceFactory.java
+++ b/dsf-tools/dsf-tools-docker-secrets-reader/src/main/java/org/highmed/dsf/tools/docker/secrets/DockerSecretsPropertySourceFactory.java
@@ -94,7 +94,7 @@ public class DockerSecretsPropertySourceFactory
 			if (secretLines.size() > 1)
 				logger.warn("secrets file for property {} contains multiple lines, using only the first line", key);
 
-			return secretLines.get(0).trim();
+			return secretLines.get(0);
 		}
 		catch (IOException e)
 		{

--- a/dsf-tools/dsf-tools-docker-secrets-reader/src/main/java/org/highmed/dsf/tools/docker/secrets/DockerSecretsPropertySourceFactory.java
+++ b/dsf-tools/dsf-tools-docker-secrets-reader/src/main/java/org/highmed/dsf/tools/docker/secrets/DockerSecretsPropertySourceFactory.java
@@ -83,7 +83,18 @@ public class DockerSecretsPropertySourceFactory
 
 		try
 		{
-			return new String(Files.readAllBytes(secretsFilePath), StandardCharsets.UTF_8);
+			List<String> secretLines = Files.readAllLines(secretsFilePath, StandardCharsets.UTF_8);
+
+			if (secretLines.isEmpty())
+			{
+				logger.warn("secrets file for property {} is empty", key);
+				return null;
+			}
+
+			if (secretLines.size() > 1)
+				logger.warn("secrets file for property {} contains multiple lines, using only the first line", key);
+
+			return secretLines.get(0).trim();
 		}
 		catch (IOException e)
 		{


### PR DESCRIPTION
- Removes CR and LF characters by using Files.readAllLines()
- Only uses the first line of a secrets file
- Trims whitespaces from passwords

fixes #254 