### PR TITLE
removes latestVersion() from the process search query config, fixes #264

### DIFF
--- a/dsf-bpe/dsf-bpe-process-base/src/main/java/org/highmed/dsf/fhir/resources/ResourceProviderImpl.java
+++ b/dsf-bpe/dsf-bpe-process-base/src/main/java/org/highmed/dsf/fhir/resources/ResourceProviderImpl.java
@@ -279,7 +279,7 @@ class ResourceProviderImpl implements ResourceProvider
 			Supplier<IParser> parserSupplier, ClassLoader classLoader, PropertyResolver resolver, String fileName,
 			Class<T> type)
 	{
-		logger.debug("Reading {} from {} and replacing all occurrence of {} with {}", type.getSimpleName(), fileName,
+		logger.debug("Reading {} from {} and replacing all occurrences of {} with {}", type.getSimpleName(), fileName,
 				VERSION_PATTERN_STRING, processPluginVersion);
 
 		try (InputStream in = classLoader.getResourceAsStream(fileName))

--- a/dsf-bpe/dsf-bpe-server/src/main/java/org/highmed/dsf/fhir/task/TaskHandler.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/org/highmed/dsf/fhir/task/TaskHandler.java
@@ -190,7 +190,7 @@ public class TaskHandler implements InitializingBean
 		if (processVersion != null && !processVersion.isBlank())
 			return repositoryService.createProcessDefinitionQuery()
 					.processDefinitionKey(processDomain + "_" + processDefinitionKey).versionTag(processVersion)
-					.latestVersion().singleResult();
+					.singleResult();
 		else
 			return repositoryService.createProcessDefinitionQuery()
 					.processDefinitionKey(processDomain + "_" + processDefinitionKey).latestVersion().singleResult();


### PR DESCRIPTION
The query config methods .versionTag(processVersion) and .latestVersion() should not be used together. A query configured this
way would only give a result if the given processVersion is the latest deployed version of the process.

fixes #264 