### PR TITLE
Issues/269 unable to instantiate process after bpe restart

### DIFF
--- a/dsf-bpe/dsf-bpe-server/src/main/java/org/highmed/dsf/bpe/plugin/ProcessPluginDefinitionAndClassLoader.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/org/highmed/dsf/bpe/plugin/ProcessPluginDefinitionAndClassLoader.java
@@ -106,13 +106,19 @@ public class ProcessPluginDefinitionAndClassLoader
 	{
 		BpmnModelInstance model = Bpmn.readModelFromStream(classLoader.getResourceAsStream(bpmnFile));
 		Bpmn.validateModel(model);
-		validateModelVersionTags(model);
+		validateModelVersionTagsAndProcessCount(bpmnFile, model);
+
 		return new BpmnFileAndModel(bpmnFile, model, jars);
 	}
 
-	private void validateModelVersionTags(BpmnModelInstance model)
+	private void validateModelVersionTagsAndProcessCount(String bpmnFile, BpmnModelInstance model)
 	{
 		Collection<Process> processes = model.getModelElementsByType(Process.class);
+
+		if (processes.size() != 1)
+			throw new RuntimeException(
+					"BPMN file " + bpmnFile + " contains " + processes.size() + " processes, expected 1");
+
 		processes.forEach(p ->
 		{
 			if (!definition.getVersion().equals(p.getCamundaVersionTag()))

--- a/dsf-bpe/dsf-bpe-server/src/main/java/org/highmed/dsf/bpe/process/BpmnFileAndModel.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/org/highmed/dsf/bpe/process/BpmnFileAndModel.java
@@ -18,6 +18,7 @@ public final class BpmnFileAndModel
 	{
 		this.file = file;
 		this.model = model;
+		
 		if (jars != null)
 			this.jars.addAll(jars);
 	}
@@ -35,5 +36,10 @@ public final class BpmnFileAndModel
 	public List<Path> getJars()
 	{
 		return Collections.unmodifiableList(jars);
+	}
+
+	public ProcessKeyAndVersion getProcessKeyAndVersion()
+	{
+		return ProcessKeyAndVersion.fromModel(getModel());
 	}
 }

--- a/dsf-bpe/dsf-bpe-server/src/main/java/org/highmed/dsf/bpe/process/BpmnFileAndModel.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/org/highmed/dsf/bpe/process/BpmnFileAndModel.java
@@ -18,7 +18,7 @@ public final class BpmnFileAndModel
 	{
 		this.file = file;
 		this.model = model;
-		
+
 		if (jars != null)
 			this.jars.addAll(jars);
 	}

--- a/dsf-bpe/dsf-bpe-server/src/main/java/org/highmed/dsf/bpe/process/ProcessKeyAndVersion.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/org/highmed/dsf/bpe/process/ProcessKeyAndVersion.java
@@ -6,6 +6,8 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.camunda.bpm.engine.repository.ProcessDefinition;
+import org.camunda.bpm.model.bpmn.BpmnModelInstance;
+import org.camunda.bpm.model.bpmn.instance.Process;
 
 public class ProcessKeyAndVersion implements Comparable<ProcessKeyAndVersion>
 {
@@ -33,6 +35,14 @@ public class ProcessKeyAndVersion implements Comparable<ProcessKeyAndVersion>
 		Objects.requireNonNull(definition, "definition");
 
 		return new ProcessKeyAndVersion(definition.getKey(), definition.getVersionTag());
+	}
+
+	public static ProcessKeyAndVersion fromModel(BpmnModelInstance model)
+	{
+		Objects.requireNonNull(model, "model");
+
+		Process process = model.getModelElementsByType(Process.class).stream().findFirst().get();
+		return new ProcessKeyAndVersion(process.getId(), process.getCamundaVersionTag());
 	}
 
 	private final String key;


### PR DESCRIPTION
fixes #269

Since we were using the bpmn filename to define the deployment name,
duplicate filtering was using filenames to determine matching existing
resources. Deploying multiple versions of the same process typically
deploys files with the same name and as such non matching files are
always found, resulting in new versions of these files/processes being
deployed. The new implementation uses process-key and version as
deployment name making bpmn filenames unique per process-key/version.