### PR TITLE
version to 0.6.0-SNAPSHOT

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,13 +1,33 @@
-cff-version: 1.1.0
-message: "If you use this software, please cite it as below."
+cff-version: 1.2.0
+message: "If you use this software, please cite both the article from preferred-citation and the software itself."
 authors:
   - family-names: Hund
     given-names: Hauke
   - family-names: Wettstein
     given-names: Reto
+  - name: Contributors of the HiGHmed DSF
+preferred-citation:
+  authors:
+    - family-names: Hund
+      given-names: Hauke
+    - family-names: Wettstein
+      given-names: Reto
+    - family-names: Heidt
+      given-names: Christian M.
+    - family-names: Kobylinski
+      given-names: Insa
+    - family-names: Fegeler
+      given-names: Christian
+  title: "Executing Distributed Healthcare and Research Processes – The HiGHmed Data Sharing Framework"
+  journal: Stud Health Technol Inform
+  volume: 278
+  year: 2021
+  pages: 126-133
+  doi: 10.3233/SHTI210060
+  type: proceedings
 title: "HiGHmed Data Sharing Framework (HiGHmed DSF)"
-version: 0.5.2
-date-released: 2021-09-07
+version: 0.6.0
+date-released: 2021-09-20
 url: https://github.com/highmed/highmed-dsf/wiki
 repository-code: https://github.com/highmed/highmed-dsf
 repository-artifact: https://github.com/highmed/highmed-dsf/releases

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -14,8 +14,6 @@ preferred-citation:
       given-names: Reto
     - family-names: Heidt
       given-names: Christian M.
-    - family-names: Kobylinski
-      given-names: Insa
     - family-names: Fegeler
       given-names: Christian
   title: "Executing Distributed Healthcare and Research Processes – The HiGHmed Data Sharing Framework"
@@ -41,8 +39,6 @@ references:
         given-names: Reto
       - family-names: Heidt
         given-names: Christian M.
-      - family-names: Kobylinski
-        given-names: Insa
       - family-names: Fegeler
         given-names: Christian
     title: "Executing Distributed Healthcare and Research Processes – The HiGHmed Data Sharing Framework"

--- a/dsf-bpe/dsf-bpe-process-base/pom.xml
+++ b/dsf-bpe/dsf-bpe-process-base/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.highmed.dsf</groupId>
 		<artifactId>dsf-bpe-pom</artifactId>
-		<version>0.5.2</version>
+		<version>0.6.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/dsf-bpe/dsf-bpe-server-jetty/pom.xml
+++ b/dsf-bpe/dsf-bpe-server-jetty/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.highmed.dsf</groupId>
 		<artifactId>dsf-bpe-pom</artifactId>
-		<version>0.5.2</version>
+		<version>0.6.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/dsf-bpe/dsf-bpe-server/pom.xml
+++ b/dsf-bpe/dsf-bpe-server/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.highmed.dsf</groupId>
 		<artifactId>dsf-bpe-pom</artifactId>
-		<version>0.5.2</version>
+		<version>0.6.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/dsf-bpe/dsf-bpe-webservice-client/pom.xml
+++ b/dsf-bpe/dsf-bpe-webservice-client/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.highmed.dsf</groupId>
 		<artifactId>dsf-bpe-pom</artifactId>
-		<version>0.5.2</version>
+		<version>0.6.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/dsf-bpe/pom.xml
+++ b/dsf-bpe/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.highmed.dsf</groupId>
 		<artifactId>dsf-pom</artifactId>
-		<version>0.5.2</version>
+		<version>0.6.0-SNAPSHOT</version>
 	</parent>
 
 	<modules>

--- a/dsf-fhir/dsf-fhir-auth/pom.xml
+++ b/dsf-fhir/dsf-fhir-auth/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.highmed.dsf</groupId>
 		<artifactId>dsf-fhir-pom</artifactId>
-		<version>0.5.2</version>
+		<version>0.6.0-SNAPSHOT</version>
 	</parent>
 	
 	<properties>

--- a/dsf-fhir/dsf-fhir-rest-adapter/pom.xml
+++ b/dsf-fhir/dsf-fhir-rest-adapter/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.highmed.dsf</groupId>
 		<artifactId>dsf-fhir-pom</artifactId>
-		<version>0.5.2</version>
+		<version>0.6.0-SNAPSHOT</version>
 	</parent>
 	
 	<properties>

--- a/dsf-fhir/dsf-fhir-server-jetty/pom.xml
+++ b/dsf-fhir/dsf-fhir-server-jetty/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.highmed.dsf</groupId>
 		<artifactId>dsf-fhir-pom</artifactId>
-		<version>0.5.2</version>
+		<version>0.6.0-SNAPSHOT</version>
 	</parent>
 	
 	<properties>

--- a/dsf-fhir/dsf-fhir-server/pom.xml
+++ b/dsf-fhir/dsf-fhir-server/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.highmed.dsf</groupId>
 		<artifactId>dsf-fhir-pom</artifactId>
-		<version>0.5.2</version>
+		<version>0.6.0-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/dsf-fhir/dsf-fhir-validation/pom.xml
+++ b/dsf-fhir/dsf-fhir-validation/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.highmed.dsf</groupId>
 		<artifactId>dsf-fhir-pom</artifactId>
-		<version>0.5.2</version>
+		<version>0.6.0-SNAPSHOT</version>
 	</parent>
 	
 	<properties>
@@ -93,7 +93,7 @@
 				</configuration>
 				<!-- Workaround for exec maven plugin issue -->
 				<!-- https://github.com/mojohaus/exec-maven-plugin/issues/76 -->
-				<!-- <dependencies> <dependency> <groupId>org.highmed.dsf</groupId> <artifactId>dsf-tools-bundle-generator</artifactId> <version>0.5.2</version> </dependency> 
+				<!-- <dependencies> <dependency> <groupId>org.highmed.dsf</groupId> <artifactId>dsf-tools-bundle-generator</artifactId> <version>0.6.0-SNAPSHOT</version> </dependency> 
 					</dependencies> -->
 			</plugin>
 		</plugins>

--- a/dsf-fhir/dsf-fhir-webservice-client/pom.xml
+++ b/dsf-fhir/dsf-fhir-webservice-client/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.highmed.dsf</groupId>
 		<artifactId>dsf-fhir-pom</artifactId>
-		<version>0.5.2</version>
+		<version>0.6.0-SNAPSHOT</version>
 	</parent>
 	
 	<properties>

--- a/dsf-fhir/dsf-fhir-websocket-client/pom.xml
+++ b/dsf-fhir/dsf-fhir-websocket-client/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.highmed.dsf</groupId>
 		<artifactId>dsf-fhir-pom</artifactId>
-		<version>0.5.2</version>
+		<version>0.6.0-SNAPSHOT</version>
 	</parent>
 	
 	<properties>

--- a/dsf-fhir/pom.xml
+++ b/dsf-fhir/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.highmed.dsf</groupId>
 		<artifactId>dsf-pom</artifactId>
-		<version>0.5.2</version>
+		<version>0.6.0-SNAPSHOT</version>
 	</parent>
 
 	<modules>

--- a/dsf-mpi/dsf-mpi-client-pdq/pom.xml
+++ b/dsf-mpi/dsf-mpi-client-pdq/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<artifactId>dsf-mpi-pom</artifactId>
 		<groupId>org.highmed.dsf</groupId>
-		<version>0.5.2</version>
+		<version>0.6.0-SNAPSHOT</version>
 	</parent>
 	
 	<properties>

--- a/dsf-mpi/dsf-mpi-client-stub/pom.xml
+++ b/dsf-mpi/dsf-mpi-client-stub/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<artifactId>dsf-mpi-pom</artifactId>
 		<groupId>org.highmed.dsf</groupId>
-		<version>0.5.2</version>
+		<version>0.6.0-SNAPSHOT</version>
 	</parent>
 	
 	<properties>

--- a/dsf-mpi/dsf-mpi-client/pom.xml
+++ b/dsf-mpi/dsf-mpi-client/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<artifactId>dsf-mpi-pom</artifactId>
 		<groupId>org.highmed.dsf</groupId>
-		<version>0.5.2</version>
+		<version>0.6.0-SNAPSHOT</version>
 	</parent>
 	
 	<properties>

--- a/dsf-mpi/pom.xml
+++ b/dsf-mpi/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<artifactId>dsf-pom</artifactId>
 		<groupId>org.highmed.dsf</groupId>
-		<version>0.5.2</version>
+		<version>0.6.0-SNAPSHOT</version>
 	</parent>
 
 	<modules>

--- a/dsf-openehr/dsf-openehr-client-impl/pom.xml
+++ b/dsf-openehr/dsf-openehr-client-impl/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<artifactId>dsf-openehr-pom</artifactId>
 		<groupId>org.highmed.dsf</groupId>
-		<version>0.5.2</version>
+		<version>0.6.0-SNAPSHOT</version>
 	</parent>
 	
 	<properties>

--- a/dsf-openehr/dsf-openehr-client-stub/pom.xml
+++ b/dsf-openehr/dsf-openehr-client-stub/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<artifactId>dsf-openehr-pom</artifactId>
 		<groupId>org.highmed.dsf</groupId>
-		<version>0.5.2</version>
+		<version>0.6.0-SNAPSHOT</version>
 	</parent>
 	
 	<properties>

--- a/dsf-openehr/dsf-openehr-client/pom.xml
+++ b/dsf-openehr/dsf-openehr-client/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<artifactId>dsf-openehr-pom</artifactId>
 		<groupId>org.highmed.dsf</groupId>
-		<version>0.5.2</version>
+		<version>0.6.0-SNAPSHOT</version>
 	</parent>
 	
 	<properties>

--- a/dsf-openehr/dsf-openehr-model/pom.xml
+++ b/dsf-openehr/dsf-openehr-model/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<artifactId>dsf-openehr-pom</artifactId>
 		<groupId>org.highmed.dsf</groupId>
-		<version>0.5.2</version>
+		<version>0.6.0-SNAPSHOT</version>
 	</parent>
 	
 	<properties>

--- a/dsf-openehr/pom.xml
+++ b/dsf-openehr/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<artifactId>dsf-pom</artifactId>
 		<groupId>org.highmed.dsf</groupId>
-		<version>0.5.2</version>
+		<version>0.6.0-SNAPSHOT</version>
 	</parent>
 
 	<modules>

--- a/dsf-pseudonymization/dsf-pseudonymization-base/pom.xml
+++ b/dsf-pseudonymization/dsf-pseudonymization-base/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.highmed.dsf</groupId>
 		<artifactId>dsf-pseudonymization-pom</artifactId>
-		<version>0.5.2</version>
+		<version>0.6.0-SNAPSHOT</version>
 	</parent>
 	
 	<properties>

--- a/dsf-pseudonymization/dsf-pseudonymization-medic/pom.xml
+++ b/dsf-pseudonymization/dsf-pseudonymization-medic/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.highmed.dsf</groupId>
 		<artifactId>dsf-pseudonymization-pom</artifactId>
-		<version>0.5.2</version>
+		<version>0.6.0-SNAPSHOT</version>
 	</parent>
 	
 	<properties>

--- a/dsf-pseudonymization/dsf-pseudonymization-ttp/pom.xml
+++ b/dsf-pseudonymization/dsf-pseudonymization-ttp/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.highmed.dsf</groupId>
 		<artifactId>dsf-pseudonymization-pom</artifactId>
-		<version>0.5.2</version>
+		<version>0.6.0-SNAPSHOT</version>
 	</parent>
 	
 	<properties>

--- a/dsf-pseudonymization/pom.xml
+++ b/dsf-pseudonymization/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.highmed.dsf</groupId>
 		<artifactId>dsf-pom</artifactId>
-		<version>0.5.2</version>
+		<version>0.6.0-SNAPSHOT</version>
 	</parent>
 
 	<modules>

--- a/dsf-tools/dsf-tools-build-info-reader/pom.xml
+++ b/dsf-tools/dsf-tools-build-info-reader/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.highmed.dsf</groupId>
 		<artifactId>dsf-tools-pom</artifactId>
-		<version>0.5.2</version>
+		<version>0.6.0-SNAPSHOT</version>
 	</parent>
 	
 	<properties>

--- a/dsf-tools/dsf-tools-bundle-generator/pom.xml
+++ b/dsf-tools/dsf-tools-bundle-generator/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.highmed.dsf</groupId>
 		<artifactId>dsf-tools-pom</artifactId>
-		<version>0.5.2</version>
+		<version>0.6.0-SNAPSHOT</version>
 	</parent>
 	
 	<properties>

--- a/dsf-tools/dsf-tools-db-migration/pom.xml
+++ b/dsf-tools/dsf-tools-db-migration/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.highmed.dsf</groupId>
 		<artifactId>dsf-tools-pom</artifactId>
-		<version>0.5.2</version>
+		<version>0.6.0-SNAPSHOT</version>
 	</parent>
 	
 	<properties>

--- a/dsf-tools/dsf-tools-docker-secrets-reader/pom.xml
+++ b/dsf-tools/dsf-tools-docker-secrets-reader/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.highmed.dsf</groupId>
 		<artifactId>dsf-tools-pom</artifactId>
-		<version>0.5.2</version>
+		<version>0.6.0-SNAPSHOT</version>
 	</parent>
 	
 	<properties>

--- a/dsf-tools/dsf-tools-proxy-test/pom.xml
+++ b/dsf-tools/dsf-tools-proxy-test/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.highmed.dsf</groupId>
 		<artifactId>dsf-tools-pom</artifactId>
-		<version>0.5.2</version>
+		<version>0.6.0-SNAPSHOT</version>
 	</parent>
 	
 	<properties>

--- a/dsf-tools/dsf-tools-test-data-generator/pom.xml
+++ b/dsf-tools/dsf-tools-test-data-generator/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.highmed.dsf</groupId>
 		<artifactId>dsf-tools-pom</artifactId>
-		<version>0.5.2</version>
+		<version>0.6.0-SNAPSHOT</version>
 	</parent>
 	
 	<properties>

--- a/dsf-tools/pom.xml
+++ b/dsf-tools/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.highmed.dsf</groupId>
 		<artifactId>dsf-pom</artifactId>
-		<version>0.5.2</version>
+		<version>0.6.0-SNAPSHOT</version>
 	</parent>
 
 	<modules>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>org.highmed.dsf</groupId>
 	<artifactId>dsf-pom</artifactId>
-	<version>0.5.2</version>
+	<version>0.6.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<modules>


### PR DESCRIPTION
Not upgrading versions of internal FHIR resources. We might need to improve our upgrade mechanism, see #277.

closes #276 