### PR TITLE
adds property replacement for bpmn files, now using #{...} instead of ${...}, adds #{date}

### DIFF
--- a/dsf-bpe/dsf-bpe-process-base/src/main/java/org/highmed/dsf/bpe/ProcessPluginDefinition.java
+++ b/dsf-bpe/dsf-bpe-process-base/src/main/java/org/highmed/dsf/bpe/ProcessPluginDefinition.java
@@ -52,7 +52,8 @@ public interface ProcessPluginDefinition
 	}
 
 	/**
-	 * @implNote Override this method to replace <code>#{date}</code> in FHIR and BPMN files with the returned value.
+	 * <i>Override this method to replace <code>#{date}</code> in FHIR and BPMN files with the returned value.</i>
+	 * 
 	 * @return the release date of the process plugin, if not overridden {@link LocalDate#MIN}
 	 * @see ResourceProvider#read(String, LocalDate, java.util.function.Supplier, ClassLoader, PropertyResolver,
 	 *      java.util.Map)
@@ -78,9 +79,9 @@ public interface ProcessPluginDefinition
 	Stream<Class<?>> getSpringConfigClasses();
 
 	/**
-	 * @implNote Override this method to return a {@link ResourceProvider} with fhir metadata resources
-	 *           (ActivityDefinition, CodeSystem, NamingSystem, StructureDefinition, ValueSet) needed by this process
-	 *           plugin.
+	 * <i>Override this method to return a {@link ResourceProvider} with fhir metadata resources (ActivityDefinition,
+	 * CodeSystem, NamingSystem, StructureDefinition, ValueSet) needed by this process plugin.</i>
+	 * 
 	 * @param fhirContext
 	 *            applications fhir context, never <code>null</code>
 	 * @param classLoader
@@ -120,8 +121,9 @@ public interface ProcessPluginDefinition
 	}
 
 	/**
-	 * @implNote Override this method to implement custom logic after a process has been deployed and is active, e.g.
-	 *           test the connection to an external server needed by a process.
+	 * <i>Override this method to implement custom logic after a process has been deployed and is active, e.g. test the
+	 * connection to an external server needed by a process.</i>
+	 * 
 	 * @param pluginApplicationContext
 	 *            the process plugin spring application context, never <code>null</code>
 	 * @param activeProcesses

--- a/dsf-bpe/dsf-bpe-process-base/src/main/java/org/highmed/dsf/fhir/organization/OrganizationProvider.java
+++ b/dsf-bpe/dsf-bpe-process-base/src/main/java/org/highmed/dsf/fhir/organization/OrganizationProvider.java
@@ -16,10 +16,14 @@ public interface OrganizationProvider
 
 	/**
 	 * @deprecated as of release 0.6.0, use {@link #getDefaultRoleSystem()} instead
+	 * @return url of the default organization type CodeSystem
 	 */
 	@Deprecated
 	String getDefaultTypeSystem();
 
+	/**
+	 * @return url of the default organization role CodeSystem
+	 */
 	String getDefaultRoleSystem();
 
 	String getLocalIdentifierValue();

--- a/dsf-bpe/dsf-bpe-process-base/src/main/java/org/highmed/dsf/fhir/resources/ResourceProvider.java
+++ b/dsf-bpe/dsf-bpe-process-base/src/main/java/org/highmed/dsf/fhir/resources/ResourceProvider.java
@@ -1,5 +1,6 @@
 package org.highmed.dsf.fhir.resources;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -94,10 +95,51 @@ public interface ResourceProvider
 		return ResourceProviderImpl.of(resourcesByProcessKeyAndVersion, dependencyResourcesByProcessKeyAndVersion);
 	}
 
+	/**
+	 * @param processPluginVersion
+	 *            version of the process plugin, e.g 1.2.3, used for replacing placeholder #{version}, not
+	 *            <code>null</code>
+	 * @param parserSupplier
+	 *            function to retrieve a {@link IParser} for parsing fhir resources, not <code>null</code>
+	 * @param classLoader
+	 *            class loader that was used to initialize the process plugin, not <code>null</code>
+	 * @param resolver
+	 *            property resolver used to access config properties and to replace place holders in fhir resources, not
+	 *            <code>null</code>
+	 * @param resourcesByProcessKeyAndVersion,
+	 *            fhir resources for this process plugin, not <code>null</code>
+	 * @return {@link ResourceProvider} for this process plugin
+	 */
 	static ResourceProvider read(String processPluginVersion, Supplier<IParser> parserSupplier, ClassLoader classLoader,
 			PropertyResolver resolver, Map<String, List<AbstractResource>> resourcesByProcessKeyAndVersion)
 	{
-		return ResourceProviderImpl.read(processPluginVersion, parserSupplier, classLoader, resolver,
+		return read(processPluginVersion, LocalDate.MIN, parserSupplier, classLoader, resolver,
+				resourcesByProcessKeyAndVersion);
+	}
+
+	/**
+	 * @param processPluginVersion
+	 *            version of the process plugin, e.g <code>"1.2.3"</code>, used for replacing placeholder #{version},
+	 *            not <code>null</code>
+	 * @param processPluginDate
+	 *            release date of the process plugin, e.g <code>LocalDate.of(2021, 2, 23)</code> , used for replacing
+	 *            placeholder #{date}, not <code>null</code>
+	 * @param parserSupplier
+	 *            function to retrieve a {@link IParser} for parsing fhir resources, not <code>null</code>
+	 * @param classLoader
+	 *            class loader that was used to initialize the process plugin, not <code>null</code>
+	 * @param resolver
+	 *            property resolver used to access config properties and to replace place holders in fhir resources, not
+	 *            <code>null</code>
+	 * @param resourcesByProcessKeyAndVersion,
+	 *            fhir resources for this process plugin, not <code>null</code>
+	 * @return {@link ResourceProvider} for this process plugin
+	 */
+	static ResourceProvider read(String processPluginVersion, LocalDate processPluginDate,
+			Supplier<IParser> parserSupplier, ClassLoader classLoader, PropertyResolver resolver,
+			Map<String, List<AbstractResource>> resourcesByProcessKeyAndVersion)
+	{
+		return ResourceProviderImpl.read(processPluginVersion, processPluginDate, parserSupplier, classLoader, resolver,
 				resourcesByProcessKeyAndVersion);
 	}
 }

--- a/dsf-bpe/dsf-bpe-server/src/main/java/org/highmed/dsf/bpe/plugin/ProcessPluginDefinitionAndClassLoader.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/org/highmed/dsf/bpe/plugin/ProcessPluginDefinitionAndClassLoader.java
@@ -1,13 +1,21 @@
 package org.highmed.dsf.bpe.plugin;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.apache.commons.io.IOUtils;
 import org.camunda.bpm.model.bpmn.Bpmn;
 import org.camunda.bpm.model.bpmn.BpmnModelInstance;
 import org.camunda.bpm.model.bpmn.instance.Process;
@@ -15,6 +23,8 @@ import org.highmed.dsf.bpe.ProcessPluginDefinition;
 import org.highmed.dsf.bpe.process.BpmnFileAndModel;
 import org.highmed.dsf.bpe.process.ProcessKeyAndVersion;
 import org.highmed.dsf.fhir.resources.ResourceProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.core.env.ConfigurableEnvironment;
@@ -24,11 +34,32 @@ import ca.uhn.fhir.context.FhirContext;
 
 public class ProcessPluginDefinitionAndClassLoader
 {
+	private static final Logger logger = LoggerFactory.getLogger(ProcessPluginDefinitionAndClassLoader.class);
+
+	private static final String VERSION_PATTERN_STRING = "#{version}";
+	private static final Pattern VERSION_PATTERN = Pattern.compile(Pattern.quote(VERSION_PATTERN_STRING));
+
+	private static final String DATE_PATTERN_STRING = "#{date}";
+	private static final Pattern DATE_PATTERN = Pattern.compile(Pattern.quote(DATE_PATTERN_STRING));
+	private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+	private static final String PLACEHOLDER_PREFIX_SPRING = "${";
+	private static final String PLACEHOLDER_PREFIX_SPRING_ESCAPED = "\\${";
+	private static final String PLACEHOLDER_PREFIX_TMP = "§{";
+	private static final String PLACEHOLDER_PREFIX = "#{";
+
+	private static final Pattern PLACEHOLDER_PREFIX_PATTERN_SPRING = Pattern
+			.compile(Pattern.quote(PLACEHOLDER_PREFIX_SPRING));
+	private static final Pattern PLACEHOLDER_PREFIX_PATTERN_TMP = Pattern
+			.compile(Pattern.quote(PLACEHOLDER_PREFIX_TMP));
+	private static final Pattern PLACEHOLDER_PREFIX_PATTERN = Pattern.compile(Pattern.quote(PLACEHOLDER_PREFIX));
+
 	private final FhirContext fhirContext;
 	private final List<Path> jars = new ArrayList<>();
 	private final ProcessPluginDefinition definition;
 	private final ClassLoader classLoader;
 	private final boolean draft;
+
 	private final PropertyResolver resolver;
 
 	private List<BpmnFileAndModel> models;
@@ -90,25 +121,65 @@ public class ProcessPluginDefinitionAndClassLoader
 
 	public List<BpmnFileAndModel> getAndValidateModels()
 	{
-		return getAndValidateModels(jars, getDefinition().getBpmnFiles(), getClassLoader());
+		return getAndValidateModels(jars, getDefinition().getBpmnFiles(), getDefinition().getVersion(),
+				getDefinition().getReleaseDate(), getClassLoader());
 	}
 
 	private List<BpmnFileAndModel> getAndValidateModels(List<Path> jars, Stream<String> bpmnFiles,
-			ClassLoader classLoader)
+			String processPluginVersion, LocalDate processPluginDate, ClassLoader classLoader)
 	{
 		if (models == null)
-			models = bpmnFiles.map(file -> loadAndValidateModel(file, classLoader, jars)).collect(Collectors.toList());
+			models = bpmnFiles
+					.map(file -> loadAndValidateModel(file, processPluginVersion, processPluginDate, classLoader, jars))
+					.collect(Collectors.toList());
 
 		return models;
 	}
 
-	private BpmnFileAndModel loadAndValidateModel(String bpmnFile, ClassLoader classLoader, List<Path> jars)
+	private BpmnFileAndModel loadAndValidateModel(String bpmnFile, String processPluginVersion,
+			LocalDate processPluginDate, ClassLoader classLoader, List<Path> jars)
 	{
-		BpmnModelInstance model = Bpmn.readModelFromStream(classLoader.getResourceAsStream(bpmnFile));
-		Bpmn.validateModel(model);
-		validateModelVersionTagsAndProcessCount(bpmnFile, model);
+		logger.debug("Reading BPMN from {} and replacing all occurrences of {} with {}", bpmnFile,
+				VERSION_PATTERN_STRING, processPluginVersion);
 
-		return new BpmnFileAndModel(bpmnFile, model, jars);
+		String processPluginDateValue = null;
+		if (processPluginDate != null && !LocalDate.MIN.equals(processPluginDate))
+		{
+			processPluginDateValue = processPluginDate.format(DATE_FORMAT);
+			logger.debug("Replacing all occurrences of {} with {}", DATE_PATTERN_STRING, processPluginDateValue);
+		}
+
+		try (InputStream in = classLoader.getResourceAsStream(bpmnFile))
+		{
+			String read = IOUtils.toString(in, StandardCharsets.UTF_8);
+
+			read = VERSION_PATTERN.matcher(read).replaceAll(processPluginVersion);
+
+			if (processPluginDateValue != null)
+				read = DATE_PATTERN.matcher(read).replaceAll(processPluginDateValue);
+
+			// escape bpmn placeholders
+			read = PLACEHOLDER_PREFIX_PATTERN_SPRING.matcher(read).replaceAll(PLACEHOLDER_PREFIX_TMP);
+			// maker dsf placeholders look like spring placeholders
+			// when calling replaceAll with ${ the $ needs to be escaped using \${
+			read = PLACEHOLDER_PREFIX_PATTERN.matcher(read).replaceAll(PLACEHOLDER_PREFIX_SPRING_ESCAPED);
+			// resolve dsf placeholders
+			read = resolver.resolveRequiredPlaceholders(read);
+			// revert bpmn placeholders
+			// when calling replaceAll with ${ the $ needs to be escaped using \${
+			read = PLACEHOLDER_PREFIX_PATTERN_TMP.matcher(read).replaceAll(PLACEHOLDER_PREFIX_SPRING_ESCAPED);
+
+			BpmnModelInstance model = Bpmn
+					.readModelFromStream(new ByteArrayInputStream(read.getBytes(StandardCharsets.UTF_8)));
+			Bpmn.validateModel(model);
+			validateModelVersionTagsAndProcessCount(bpmnFile, model);
+
+			return new BpmnFileAndModel(bpmnFile, model, jars);
+		}
+		catch (IOException e)
+		{
+			throw new RuntimeException("Error while reading " + bpmnFile, e);
+		}
 	}
 
 	private void validateModelVersionTagsAndProcessCount(String bpmnFile, BpmnModelInstance model)

--- a/dsf-fhir/dsf-fhir-validation/src/main/java/org/highmed/dsf/fhir/validation/StructureDefinitionReader.java
+++ b/dsf-fhir/dsf-fhir-validation/src/main/java/org/highmed/dsf/fhir/validation/StructureDefinitionReader.java
@@ -5,6 +5,8 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -19,11 +21,22 @@ import ca.uhn.fhir.parser.DataFormatException;
 
 public class StructureDefinitionReader
 {
-	private static final String VERSION_PATTERN_STRING = "${version}";
-	private static final Pattern VERSION_PATTERN = Pattern.compile(Pattern.quote(VERSION_PATTERN_STRING));
+	private static final String VERSION_PATTERN_STRING1 = "#{version}";
+	private static final Pattern VERSION_PATTERN1 = Pattern.compile(Pattern.quote(VERSION_PATTERN_STRING1));
+	// ${...} pattern to be backwards compatible
+	private static final String VERSION_PATTERN_STRING2 = "${version}";
+	private static final Pattern VERSION_PATTERN2 = Pattern.compile(Pattern.quote(VERSION_PATTERN_STRING2));
+
+	private static final String DATE_PATTERN_STRING1 = "#{date}";
+	private static final Pattern DATE_PATTERN1 = Pattern.compile(Pattern.quote(DATE_PATTERN_STRING1));
+	// ${...} pattern to be backwards compatible
+	private static final String DATE_PATTERN_STRING2 = "${date}";
+	private static final Pattern DATE_PATTERN2 = Pattern.compile(Pattern.quote(DATE_PATTERN_STRING2));
+	private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
 	private final FhirContext context;
 	private final String version;
+	private final LocalDate date;
 
 	public StructureDefinitionReader(FhirContext context)
 	{
@@ -32,8 +45,14 @@ public class StructureDefinitionReader
 
 	public StructureDefinitionReader(FhirContext context, String version)
 	{
+		this(context, version, LocalDate.MIN);
+	}
+
+	public StructureDefinitionReader(FhirContext context, String version, LocalDate date)
+	{
 		this.context = context;
 		this.version = version;
+		this.date = date;
 	}
 
 	public List<StructureDefinition> readXml(Path... xmlPaths)
@@ -68,7 +87,7 @@ public class StructureDefinitionReader
 
 	public StructureDefinition readXml(Path xmlPath)
 	{
-		return version == null ? doReadXml(xmlPath) : doReadXmlAndReplaceVersion(xmlPath, version);
+		return version == null ? doReadXml(xmlPath) : doReadXmlAndReplaceVersion(xmlPath, version, date);
 	}
 
 	private StructureDefinition doReadXml(Path xmlPath)
@@ -83,12 +102,12 @@ public class StructureDefinitionReader
 		}
 	}
 
-	private StructureDefinition doReadXmlAndReplaceVersion(Path xmlPath, String version)
+	private StructureDefinition doReadXmlAndReplaceVersion(Path xmlPath, String version, LocalDate date)
 	{
 		try (InputStream in = Files.newInputStream(xmlPath))
 		{
 			String read = IOUtils.toString(in, StandardCharsets.UTF_8);
-			read = VERSION_PATTERN.matcher(read).replaceAll(version);
+			read = replaceVersionAndDate(read, version, date);
 
 			return context.newXmlParser().parseResource(StructureDefinition.class, read);
 		}
@@ -98,9 +117,23 @@ public class StructureDefinitionReader
 		}
 	}
 
+	private String replaceVersionAndDate(String read, String version, LocalDate date)
+	{
+		read = VERSION_PATTERN1.matcher(read).replaceAll(version);
+		read = VERSION_PATTERN2.matcher(read).replaceAll(version);
+
+		if (date != null && !LocalDate.MIN.equals(date))
+		{
+			String dateValue = date.format(DATE_FORMAT);
+			read = DATE_PATTERN1.matcher(read).replaceAll(dateValue);
+			read = DATE_PATTERN2.matcher(read).replaceAll(dateValue);
+		}
+		return read;
+	}
+
 	public StructureDefinition readXml(String xmlOnClassPath)
 	{
-		return version == null ? doReadXml(xmlOnClassPath) : doReadXmlAndReplaceVersion(xmlOnClassPath, version);
+		return version == null ? doReadXml(xmlOnClassPath) : doReadXmlAndReplaceVersion(xmlOnClassPath, version, date);
 	}
 
 	private StructureDefinition doReadXml(String xmlOnClassPath)
@@ -115,12 +148,12 @@ public class StructureDefinitionReader
 		}
 	}
 
-	private StructureDefinition doReadXmlAndReplaceVersion(String xmlOnClassPath, String version)
+	private StructureDefinition doReadXmlAndReplaceVersion(String xmlOnClassPath, String version, LocalDate date)
 	{
 		try (InputStream in = StructureDefinitionReader.class.getResourceAsStream(xmlOnClassPath))
 		{
 			String read = IOUtils.toString(in, StandardCharsets.UTF_8);
-			read = VERSION_PATTERN.matcher(read).replaceAll(version);
+			read = replaceVersionAndDate(read, version, date);
 
 			return context.newXmlParser().parseResource(StructureDefinition.class, read);
 		}


### PR DESCRIPTION
Adds a property replacements mechanism to bpmn files, similar to fhir resources. #{version} and #{date} can be used in addition to all spring managed properties. #{date} is defined via the new ProcessPluginDefinition#getReleaseDate() method.

Place holders in fhir and bpmn files should use the pattern #{...} now, since ${...} can't be used in bpmn files, since it is already used by camunda.

Adds the new placeholder #{date}/${date} to the replacement mechanism of fhir files. Replacement within fhir resources still works with the old ${...} pattern.

closes #248