### PR TITLE
adds conditional read to client, adds conditional read test, fixes #206

### DIFF
--- a/dsf-fhir/dsf-fhir-server/src/test/java/org/highmed/dsf/fhir/integration/BinaryIntegrationTest.java
+++ b/dsf-fhir/dsf-fhir-server/src/test/java/org/highmed/dsf/fhir/integration/BinaryIntegrationTest.java
@@ -2608,6 +2608,9 @@ public class BinaryIntegrationTest extends AbstractIntegrationTest
 		Binary read2 = getWebserviceClient().read(createdWithoutVersion);
 		assertTrue(createdWithoutVersion == read2);
 
+		// sleeping for 1 second to make sure version two is at least 1 second newer
+		Thread.sleep(1000L);
+
 		Binary updated = getWebserviceClient().update(created);
 		assertNotEquals(created.getMeta().getVersionId(), updated.getMeta().getVersionId());
 

--- a/dsf-fhir/dsf-fhir-server/src/test/java/org/highmed/dsf/fhir/integration/BinaryIntegrationTest.java
+++ b/dsf-fhir/dsf-fhir-server/src/test/java/org/highmed/dsf/fhir/integration/BinaryIntegrationTest.java
@@ -2,6 +2,7 @@ package org.highmed.dsf.fhir.integration;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -2587,5 +2588,35 @@ public class BinaryIntegrationTest extends AbstractIntegrationTest
 		String binaryId = binary.getIdElement().getIdPart();
 
 		expectForbidden(() -> getExternalWebserviceClient().read(Binary.class, binaryId));
+	}
+
+	@Test
+	public void testConditionalRequest() throws Exception
+	{
+		Binary binary = new Binary();
+		binary.setContentType(MediaType.TEXT_PLAIN);
+		binary.setData("Hello World".getBytes(StandardCharsets.UTF_8));
+		getReadAccessHelper().addAll(binary);
+
+		Binary created = getWebserviceClient().create(binary);
+
+		Binary read1 = getWebserviceClient().read(created);
+		assertTrue(created == read1);
+
+		Binary createdWithoutVersion = created.copy();
+		createdWithoutVersion.getMeta().setVersionId(null);
+		Binary read2 = getWebserviceClient().read(createdWithoutVersion);
+		assertTrue(createdWithoutVersion == read2);
+
+		Binary updated = getWebserviceClient().update(created);
+		assertNotEquals(created.getMeta().getVersionId(), updated.getMeta().getVersionId());
+
+		Binary read3 = getWebserviceClient().read(created);
+		assertFalse(created == read3);
+		assertEquals(updated.getMeta().getVersionId(), read3.getMeta().getVersionId());
+
+		Binary read4 = getWebserviceClient().read(createdWithoutVersion);
+		assertFalse(createdWithoutVersion == read4);
+		assertEquals(updated.getMeta().getVersionId(), read4.getMeta().getVersionId());
 	}
 }

--- a/dsf-fhir/dsf-fhir-webservice-client/src/main/java/org/highmed/fhir/client/BasicFhirWebserviceCientWithRetryImpl.java
+++ b/dsf-fhir/dsf-fhir-webservice-client/src/main/java/org/highmed/fhir/client/BasicFhirWebserviceCientWithRetryImpl.java
@@ -107,6 +107,12 @@ class BasicFhirWebserviceCientWithRetryImpl extends AbstractFhirWebserviceClient
 	}
 
 	@Override
+	public <R extends Resource> R read(R oldValue)
+	{
+		return retry(nTimes, delayMillis, () -> delegate.read(oldValue));
+	}
+
+	@Override
 	public Resource read(String resourceTypeName, String id)
 	{
 		return retry(nTimes, delayMillis, () -> delegate.read(resourceTypeName, id));

--- a/dsf-fhir/dsf-fhir-webservice-client/src/main/java/org/highmed/fhir/client/BasicFhirWebserviceClient.java
+++ b/dsf-fhir/dsf-fhir-webservice-client/src/main/java/org/highmed/fhir/client/BasicFhirWebserviceClient.java
@@ -22,7 +22,26 @@ public interface BasicFhirWebserviceClient extends PreferReturnResource
 
 	Resource read(String resourceTypeName, String id);
 
+	/**
+	 * @param <R>
+	 * @param resourceType
+	 *            not <code>null</code>
+	 * @param id
+	 *            not <code>null</code>
+	 * @return
+	 */
 	<R extends Resource> R read(Class<R> resourceType, String id);
+
+	/**
+	 * Uses If-None-Match and If-Modified-Since Headers based on the version and lastUpdated values in <b>oldValue</b>
+	 * to check if the resource has been modified.
+	 *
+	 * @param <R>
+	 * @param oldValue
+	 *            not <code>null</code>
+	 * @return oldValue (same object) if server send 304 - Not Modified, else value returned from server
+	 */
+	<R extends Resource> R read(R oldValue);
 
 	<R extends Resource> boolean exists(Class<R> resourceType, String id);
 


### PR DESCRIPTION
* Adds a conditional read method to the FHIR client
* Adds a conditional read test to the BinaryIntegrationTest

Our ifNoneMatch implementation within AbstractResourceServiceImpl could be improved, since it currently only supports a single value in the If-None-Match header. Example with multiple values see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match#syntax

fixes #206