### PR TITLE
missing, empty and wildcard */* Accept Header now supported, #312 fix

### DIFF
--- a/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/help/ParameterConverter.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/help/ParameterConverter.java
@@ -115,6 +115,9 @@ public class ParameterConverter
 
 	private Optional<MediaType> getMediaType(String mediaType, boolean pretty)
 	{
+		if (mediaType == null || mediaType.isBlank())
+			mediaType = MediaType.WILDCARD;
+
 		if (mediaType.contains(MediaType.TEXT_HTML))
 			return Optional.of(mediaType("text", "html", pretty));
 		else if (mediaType.contains(Constants.CT_FHIR_JSON_NEW))
@@ -131,6 +134,8 @@ public class ParameterConverter
 			return Optional.of(mediaType("application", "xml", pretty));
 		else if (mediaType.contains(MediaType.TEXT_XML))
 			return Optional.of(mediaType("text", "xml", pretty));
+		else if (mediaType.contains(MediaType.WILDCARD))
+			return Optional.of(mediaType("application", "fhir+xml", pretty));
 		else
 			return Optional.empty();
 	}


### PR DESCRIPTION
Server will send `application/fhir+xml` if accept header missing, value empty or wildcard aka `*/*`

fixes #312