### PR TITLE
adds environment variables to set connection and read timeout in seconds

### DIFF
--- a/dsf-docker/fhir_proxy/Dockerfile
+++ b/dsf-docker/fhir_proxy/Dockerfile
@@ -12,11 +12,11 @@ ENV SSL_CERTIFICATE_CHAIN_FILE="/does/not/exist"
 ENV SSL_CA_DN_REQUEST_FILE="/does/not/exist"
 
 # timeout (seconds) for reverse proxy to app server http connection, time the proxy waits for a reply
-ENV PROXY_PASS_HTTP_TIMEOUT=60
+ENV PROXY_PASS_TIMEOUT_HTTP=60
 # timeout (seconds) for reverse proxy to app server ws connection, time the proxy waits for a reply
-ENV PROXY_PASS_WS_TIMEOUT=60
+ENV PROXY_PASS_TIMEOUT_WS=60
 
 # connection timeout (seconds) for reverse proxy to app server http connection, time the proxy waits for a connection to be established 
-ENV PROXY_PASS_HTTP_CONNECTION_TIMEOUT=30
+ENV PROXY_PASS_CONNECTION_TIMEOUT_HTTP=30
 # connection timeout (seconds) for reverse proxy to app server ws connection, time the proxy waits for a connection to be established
-ENV PROXY_PASS_WS_CONNECTION_TIMEOUT=30
+ENV PROXY_PASS_CONNECTION_TIMEOUT_WS=30

--- a/dsf-docker/fhir_proxy/Dockerfile
+++ b/dsf-docker/fhir_proxy/Dockerfile
@@ -10,3 +10,13 @@ RUN mkdir /usr/local/apache2/ssl/ && \
 # setting non existing default values, see host-ssl.conf IfFile tests
 ENV SSL_CERTIFICATE_CHAIN_FILE="/does/not/exist"
 ENV SSL_CA_DN_REQUEST_FILE="/does/not/exist"
+
+# timeout (seconds) for reverse proxy to app server http connection, time the proxy waits for a reply
+ENV PROXY_PASS_HTTP_TIMEOUT=60
+# timeout (seconds) for reverse proxy to app server ws connection, time the proxy waits for a reply
+ENV PROXY_PASS_WS_TIMEOUT=60
+
+# connection timeout (seconds) for reverse proxy to app server http connection, time the proxy waits for a connection to be established 
+ENV PROXY_PASS_HTTP_CONNECTION_TIMEOUT=30
+# connection timeout (seconds) for reverse proxy to app server ws connection, time the proxy waits for a connection to be established
+ENV PROXY_PASS_WS_CONNECTION_TIMEOUT=30

--- a/dsf-docker/fhir_proxy/conf/extra/host-ssl.conf
+++ b/dsf-docker/fhir_proxy/conf/extra/host-ssl.conf
@@ -38,14 +38,14 @@ Header always set Strict-Transport-Security "max-age=63072000; includeSubDomains
 <Location "/fhir">
 	RequestHeader set X-ClientCert %{SSL_CLIENT_CERT}s
 
-	ProxyPass http://${APP_SERVER_IP}:8080/fhir
+	ProxyPass http://${APP_SERVER_IP}:8080/fhir timeout=${PROXY_PASS_HTTP_TIMEOUT} connectiontimeout=${PROXY_PASS_HTTP_CONNECTION_TIMEOUT}
 	ProxyPassReverse http://${APP_SERVER_IP}:8080/fhir
 </Location>
 <Location "/fhir/ws">
 	RequestHeader set X-ClientCert %{SSL_CLIENT_CERT}s
 
 	ProxyWebsocketFallbackToProxyHttp off
-	ProxyPass ws://${APP_SERVER_IP}:8080/fhir/ws
+	ProxyPass ws://${APP_SERVER_IP}:8080/fhir/ws timeout=${PROXY_PASS_WS_TIMEOUT} connectiontimeout=${PROXY_PASS_HTTP_CONNECTION_TIMEOUT}
 	ProxyPassReverse ws://${APP_SERVER_IP}:8080/fhir/ws
 </Location>
 

--- a/dsf-docker/fhir_proxy/conf/extra/host-ssl.conf
+++ b/dsf-docker/fhir_proxy/conf/extra/host-ssl.conf
@@ -38,14 +38,14 @@ Header always set Strict-Transport-Security "max-age=63072000; includeSubDomains
 <Location "/fhir">
 	RequestHeader set X-ClientCert %{SSL_CLIENT_CERT}s
 
-	ProxyPass http://${APP_SERVER_IP}:8080/fhir timeout=${PROXY_PASS_HTTP_TIMEOUT} connectiontimeout=${PROXY_PASS_HTTP_CONNECTION_TIMEOUT}
+	ProxyPass http://${APP_SERVER_IP}:8080/fhir timeout=${PROXY_PASS_TIMEOUT_HTTP} connectiontimeout=${PROXY_PASS_CONNECTION_TIMEOUT_HTTP}
 	ProxyPassReverse http://${APP_SERVER_IP}:8080/fhir
 </Location>
 <Location "/fhir/ws">
 	RequestHeader set X-ClientCert %{SSL_CLIENT_CERT}s
 
 	ProxyWebsocketFallbackToProxyHttp off
-	ProxyPass ws://${APP_SERVER_IP}:8080/fhir/ws timeout=${PROXY_PASS_WS_TIMEOUT} connectiontimeout=${PROXY_PASS_HTTP_CONNECTION_TIMEOUT}
+	ProxyPass ws://${APP_SERVER_IP}:8080/fhir/ws timeout=${PROXY_PASS_TIMEOUT_WS} connectiontimeout=${PROXY_PASS_CONNECTION_TIMEOUT_WS}
 	ProxyPassReverse ws://${APP_SERVER_IP}:8080/fhir/ws
 </Location>
 


### PR DESCRIPTION
Connection and read timeouts between the reverse proxy and the app server can now be configured via environment variables in seconds. Variable are named after the apache mod_proxy ProxyPass parameters `timeout` (read timeout) and `connectiontimeout` (connect timeout). Default values are:

```
PROXY_PASS_TIMEOUT_HTTP=60
PROXY_PASS_TIMEOUT_WS=60
PROXY_PASS_CONNECTION_TIMEOUT_HTTP=30
PROXY_PASS_CONNECTION_TIMEOUT_WS=30
```

closes #313