### PR TITLE
improved error handling and logging for Task message sends, fixes #273

### DIFF
--- a/dsf-bpe/dsf-bpe-process-base/src/main/java/org/highmed/dsf/fhir/variables/Targets.java
+++ b/dsf-bpe/dsf-bpe-process-base/src/main/java/org/highmed/dsf/fhir/variables/Targets.java
@@ -24,8 +24,13 @@ public class Targets
 		return Collections.unmodifiableList(entries);
 	}
 
-	public void removeTarget(Target target)
+	public boolean removeTarget(Target target)
 	{
-		entries.remove(target);
+		return entries.remove(target);
+	}
+
+	public boolean isEmpty()
+	{
+		return entries.isEmpty();
 	}
 }

--- a/dsf-bpe/dsf-bpe-server/src/main/java/org/highmed/dsf/bpe/listener/EndListener.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/org/highmed/dsf/bpe/listener/EndListener.java
@@ -83,7 +83,8 @@ public class EndListener implements ExecutionListener
 				CODESYSTEM_HIGHMED_BPMN_VALUE_CORRELATION_KEY).orElse(null);
 		String taskId = task.getIdElement().getIdPart();
 
-		logger.info("Process {} finished [message: {}, businessKey: {}, correlationKey: {}, taskId: {}]", processUrl,
-				messageName, businessKey, correlationKey, taskId);
+		logger.info(
+				"Process {} finished with Task status {} [message: {}, businessKey: {}, correlationKey: {}, taskId: {}]",
+				processUrl, task.getStatus().toCode(), messageName, businessKey, correlationKey, taskId);
 	}
 }


### PR DESCRIPTION
Task message sends result in a failed process if a Message End Event, Message Intermediate Throw Event or Send Task with a single target fail to send their Task or if a multi-instance Send Task fails to send Tasks to all intended targets (failing after the last failed send attempt).