### PR TITLE
allows process plugins to fail during startup without crashing the BPE

### DIFF
--- a/dsf-bpe/dsf-bpe-server/src/main/java/org/highmed/dsf/bpe/service/BpmnServiceDelegateValidationServiceImpl.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/org/highmed/dsf/bpe/service/BpmnServiceDelegateValidationServiceImpl.java
@@ -143,9 +143,8 @@ public class BpmnServiceDelegateValidationServiceImpl implements BpmnServiceDele
 		}
 		catch (BeansException e)
 		{
-			logger.warn("Error while getting service delegate bean of type {} defined in process {}: {}",
+			logger.error("Unable to find service delegate bean of type {} defined in process {}: {}",
 					serviceClass.getName(), processKeyAndVersion, e.getMessage());
-			throw new RuntimeException(e);
 		}
 	}
 }


### PR DESCRIPTION
BeanCreationExceptions due to errors during initialization of spring beans in plugins are now caught and an empty (aka no beans) application context is used for a failed process plugin. Because of this, JavaDelegates for BPMN Tasks may not exist. This will now result in a warning, not a crash of the BPE.

fixes #335