### PR TITLE
new json object mapper configuration, only explicit declarations allowed

### DIFF
--- a/dsf-bpe/dsf-bpe-process-base/src/main/java/org/highmed/dsf/fhir/json/ObjectMapperFactory.java
+++ b/dsf-bpe/dsf-bpe-process-base/src/main/java/org/highmed/dsf/fhir/json/ObjectMapperFactory.java
@@ -1,0 +1,36 @@
+package org.highmed.dsf.fhir.json;
+
+import org.highmed.dsf.fhir.variables.FhirResourceJacksonDeserializer;
+import org.highmed.dsf.fhir.variables.FhirResourceJacksonSerializer;
+import org.highmed.openehr.json.OpenEhrObjectMapperFactory;
+import org.hl7.fhir.r4.model.Resource;
+
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+import ca.uhn.fhir.context.FhirContext;
+
+public class ObjectMapperFactory
+{
+	private ObjectMapperFactory()
+	{
+	}
+
+	public static ObjectMapper createObjectMapper(FhirContext fhirContext)
+	{
+		return JsonMapper.builder().serializationInclusion(Include.NON_NULL).serializationInclusion(Include.NON_EMPTY)
+				.addModule(fhirModule(fhirContext)).addModule(OpenEhrObjectMapperFactory.openEhrModule())
+				.disable(MapperFeature.AUTO_DETECT_CREATORS).disable(MapperFeature.AUTO_DETECT_FIELDS)
+				.disable(MapperFeature.AUTO_DETECT_GETTERS).disable(MapperFeature.AUTO_DETECT_IS_GETTERS)
+				.disable(MapperFeature.AUTO_DETECT_SETTERS).build();
+	}
+
+	public static SimpleModule fhirModule(FhirContext fhirContext)
+	{
+		return new SimpleModule().addSerializer(Resource.class, new FhirResourceJacksonSerializer(fhirContext))
+				.addDeserializer(Resource.class, new FhirResourceJacksonDeserializer(fhirContext));
+	}
+}

--- a/dsf-bpe/dsf-bpe-process-base/src/main/java/org/highmed/dsf/fhir/variables/FhirResourcesList.java
+++ b/dsf-bpe/dsf-bpe-process-base/src/main/java/org/highmed/dsf/fhir/variables/FhirResourcesList.java
@@ -27,6 +27,7 @@ public class FhirResourcesList
 		this(Arrays.asList(resources));
 	}
 
+	@JsonProperty("resources")
 	public List<Resource> getResources()
 	{
 		return Collections.unmodifiableList(resources);

--- a/dsf-bpe/dsf-bpe-process-base/src/main/java/org/highmed/dsf/fhir/variables/Target.java
+++ b/dsf-bpe/dsf-bpe-process-base/src/main/java/org/highmed/dsf/fhir/variables/Target.java
@@ -35,16 +35,19 @@ public class Target
 		return new Target(targetOrganizationIdentifierValue, targetEndpointUrl, correlationKey);
 	}
 
+	@JsonProperty("targetOrganizationIdentifierValue")
 	public String getTargetOrganizationIdentifierValue()
 	{
 		return targetOrganizationIdentifierValue;
 	}
 
+	@JsonProperty("targetEndpointUrl")
 	public String getTargetEndpointUrl()
 	{
 		return targetEndpointUrl;
 	}
 
+	@JsonProperty("correlationKey")
 	public String getCorrelationKey()
 	{
 		if (correlationKey == null)

--- a/dsf-bpe/dsf-bpe-process-base/src/main/java/org/highmed/dsf/fhir/variables/Targets.java
+++ b/dsf-bpe/dsf-bpe-process-base/src/main/java/org/highmed/dsf/fhir/variables/Targets.java
@@ -19,6 +19,7 @@ public class Targets
 			this.entries.addAll(targets);
 	}
 
+	@JsonProperty("entries")
 	public List<Target> getEntries()
 	{
 		return Collections.unmodifiableList(entries);

--- a/dsf-bpe/dsf-bpe-process-base/src/test/java/org/highmed/dsf/fhir/variables/FhirResourceListSerializationTest.java
+++ b/dsf-bpe/dsf-bpe-process-base/src/test/java/org/highmed/dsf/fhir/variables/FhirResourceListSerializationTest.java
@@ -1,0 +1,61 @@
+package org.highmed.dsf.fhir.variables;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.highmed.dsf.fhir.json.ObjectMapperFactory;
+import org.hl7.fhir.r4.model.Patient;
+import org.hl7.fhir.r4.model.Task;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import ca.uhn.fhir.context.FhirContext;
+
+public class FhirResourceListSerializationTest
+{
+	private static final Logger logger = LoggerFactory.getLogger(FhirResourceListSerializationTest.class);
+
+	@Test
+	public void testEmptyFhirResourceListSerialization() throws Exception
+	{
+		ObjectMapper mapper = ObjectMapperFactory.createObjectMapper(FhirContext.forR4());
+
+		FhirResourcesList list = new FhirResourcesList();
+
+		String listAsString = mapper.writeValueAsString(list);
+		assertNotNull(listAsString);
+
+		logger.debug("Empty fhir resource list json: '{}'", listAsString);
+
+		FhirResourcesList readList = mapper.readValue(listAsString, FhirResourcesList.class);
+		assertNotNull(readList);
+		assertNotNull(readList.getResources());
+		assertNotNull(readList.getResourcesAndCast());
+		assertTrue(readList.getResources().isEmpty());
+	}
+
+	@Test
+	public void testNonEmptyFhirResourceListSerialization() throws Exception
+	{
+		ObjectMapper mapper = ObjectMapperFactory.createObjectMapper(FhirContext.forR4());
+
+		Task task = new Task();
+		Patient patient = new Patient();
+		FhirResourcesList list = new FhirResourcesList(task, patient);
+
+		String listAsString = mapper.writeValueAsString(list);
+		assertNotNull(listAsString);
+
+		logger.debug("Non empty fhir resource list json: '{}'", listAsString);
+
+		FhirResourcesList readList = mapper.readValue(listAsString, FhirResourcesList.class);
+		assertNotNull(readList);
+		assertNotNull(readList.getResources());
+		assertNotNull(readList.getResourcesAndCast());
+		assertEquals(2, readList.getResources().size());
+	}
+}

--- a/dsf-bpe/dsf-bpe-process-base/src/test/java/org/highmed/dsf/fhir/variables/TargetsJsonSerializationTest.java
+++ b/dsf-bpe/dsf-bpe-process-base/src/test/java/org/highmed/dsf/fhir/variables/TargetsJsonSerializationTest.java
@@ -1,0 +1,92 @@
+package org.highmed.dsf.fhir.variables;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collections;
+import java.util.UUID;
+
+import org.highmed.dsf.fhir.json.ObjectMapperFactory;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import ca.uhn.fhir.context.FhirContext;
+
+public class TargetsJsonSerializationTest
+{
+	private static final Logger logger = LoggerFactory.getLogger(TargetsJsonSerializationTest.class);
+
+	@Test
+	public void testEmptyTargetsSerialization() throws Exception
+	{
+		ObjectMapper mapper = ObjectMapperFactory.createObjectMapper(FhirContext.forR4());
+
+		Targets targets = new Targets(Collections.emptyList());
+
+		String targetsAsString = mapper.writeValueAsString(targets);
+		assertNotNull(targetsAsString);
+
+		logger.debug("Empty targests json: '{}'", targetsAsString);
+
+		Targets readTargets = mapper.readValue(targetsAsString, Targets.class);
+		assertNotNull(readTargets);
+		assertTrue(readTargets.isEmpty());
+	}
+
+	@Test
+	public void testTargetsWithBiDirectionalTargetSerialization() throws Exception
+	{
+		ObjectMapper mapper = ObjectMapperFactory.createObjectMapper(FhirContext.forR4());
+
+		Target target = Target.createBiDirectionalTarget("target.org", "https://target.org/fhir",
+				UUID.randomUUID().toString());
+		Targets targets = new Targets(Collections.singleton(target));
+
+		String targetsAsString = mapper.writeValueAsString(targets);
+		assertNotNull(targetsAsString);
+
+		logger.debug("Targets with bi-directional target json: '{}'", targetsAsString);
+
+		Targets readTargets = mapper.readValue(targetsAsString, Targets.class);
+		assertNotNull(readTargets);
+		assertFalse(readTargets.isEmpty());
+		assertNotNull(readTargets.getEntries());
+		assertEquals(1, readTargets.getEntries().size());
+
+		targetEquals(target, readTargets.getEntries().get(0));
+	}
+
+	@Test
+	public void testTargetsWithUniDirectionalTargetSerialization() throws Exception
+	{
+		ObjectMapper mapper = ObjectMapperFactory.createObjectMapper(FhirContext.forR4());
+
+		Target target = Target.createUniDirectionalTarget("target.org", "https://target.org/fhir");
+		Targets targets = new Targets(Collections.singleton(target));
+
+		String targetsAsString = mapper.writeValueAsString(targets);
+		assertNotNull(targetsAsString);
+
+		logger.debug("Targets with Uni directional target json: '{}'", targetsAsString);
+
+		Targets readTargets = mapper.readValue(targetsAsString, Targets.class);
+		assertNotNull(readTargets);
+		assertFalse(readTargets.isEmpty());
+		assertNotNull(readTargets.getEntries());
+		assertEquals(1, readTargets.getEntries().size());
+
+		targetEquals(target, readTargets.getEntries().get(0));
+	}
+
+	private void targetEquals(Target expected, Target actual)
+	{
+		assertEquals(expected.getCorrelationKey(), actual.getCorrelationKey());
+		assertEquals(expected.getTargetEndpointUrl(), actual.getTargetEndpointUrl());
+		assertEquals(expected.getTargetOrganizationIdentifierValue(), actual.getTargetOrganizationIdentifierValue());
+	}
+}

--- a/dsf-bpe/dsf-bpe-process-base/src/test/resources/log4j2.xml
+++ b/dsf-bpe/dsf-bpe-process-base/src/test/resources/log4j2.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="INFO" monitorInterval="30" verbose="false">
+
+	<Appenders>
+		<Console name="CONSOLE" target="SYSTEM_OUT">
+			<PatternLayout pattern="%p\t%t - %C{1}.%M(%L) | %m%n"/>
+		</Console>
+	</Appenders>
+
+	<Loggers>
+		<Logger name="de.rwh" level="TRACE"/>
+		<Logger name="org.highmed" level="TRACE"/>
+		<Logger name="org.apache" level="WARN"/>
+		<Logger name="org.springframework" level="WARN"/>
+		<Logger name="jndi" level="WARN"/>
+		<Logger name="org.eclipse.jetty" level="INFO"/>
+		<Logger name="com.sun.jersey" level="WARN"/>
+		<Logger name="liquibase" level="WARN"/>
+		<Logger name="ca.uhn.hl7v2" level="WARN"/>
+		
+		<Root level="WARN">
+			<AppenderRef ref="CONSOLE"/>
+		</Root>
+	</Loggers>
+</Configuration>

--- a/dsf-bpe/dsf-bpe-server/src/main/java/org/highmed/dsf/bpe/spring/config/SerializerConfig.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/org/highmed/dsf/bpe/spring/config/SerializerConfig.java
@@ -1,20 +1,15 @@
 package org.highmed.dsf.bpe.spring.config;
 
-import org.highmed.dsf.fhir.variables.FhirResourceJacksonDeserializer;
-import org.highmed.dsf.fhir.variables.FhirResourceJacksonSerializer;
+import org.highmed.dsf.fhir.json.ObjectMapperFactory;
 import org.highmed.dsf.fhir.variables.FhirResourceSerializer;
 import org.highmed.dsf.fhir.variables.FhirResourcesListSerializer;
 import org.highmed.dsf.fhir.variables.TargetSerializer;
 import org.highmed.dsf.fhir.variables.TargetsSerializer;
-import org.highmed.openehr.json.OpenEhrObjectMapperFactory;
-import org.hl7.fhir.r4.model.Resource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.module.SimpleModule;
 
 import ca.uhn.fhir.context.FhirContext;
 
@@ -27,19 +22,7 @@ public class SerializerConfig
 	@Bean
 	public ObjectMapper objectMapper()
 	{
-		ObjectMapper mapper = new ObjectMapper();
-
-		mapper.setSerializationInclusion(Include.NON_NULL);
-		mapper.setSerializationInclusion(Include.NON_EMPTY);
-
-		SimpleModule module = new SimpleModule();
-		module.addSerializer(Resource.class, new FhirResourceJacksonSerializer(fhirContext));
-		module.addDeserializer(Resource.class, new FhirResourceJacksonDeserializer(fhirContext));
-
-		mapper.registerModule(module);
-		mapper.registerModule(OpenEhrObjectMapperFactory.openEhrModule());
-
-		return mapper;
+		return ObjectMapperFactory.createObjectMapper(fhirContext);
 	}
 
 	@Bean


### PR DESCRIPTION
With the new json object mapper configuration auto detection of creators, fields, getters, is-getters and setters is disabled. Elements need to be explicitly annotated for example using @JsonCreator or @JsonProperty.

For testing serialization of BPE variables, process plugins can use the new org.highmed.dsf.fhir.json.ObjectMapperFactory to create a ObjectMapper that is configured equally to the one used within the DSF BPE.

This change means that developers of process plugins using custom BPE variables need to add omitted json annotations in order for the variables to sill work.

closes #339