### PR TITLE
Issues/331 add bookmarking function to html output

### DIFF
--- a/dsf-fhir/dsf-fhir-rest-adapter/src/main/java/org/highmed/dsf/fhir/adapter/HtmlFhirAdapter.java
+++ b/dsf-fhir/dsf-fhir-rest-adapter/src/main/java/org/highmed/dsf/fhir/adapter/HtmlFhirAdapter.java
@@ -62,7 +62,7 @@ public class HtmlFhirAdapter<T extends BaseResource> implements MessageBodyWrite
 	private static final Pattern URL_PATTERN = Pattern
 			.compile("(https?)://[-a-zA-Z0-9+&@#/%?=~_|!:,.;]*[-a-zA-Z0-9+&@#/%=~_.|]");
 	private static final Pattern XML_REFERENCE_UUID_PATTERN = Pattern
-			.compile("&lt;reference value=\"((" + RESOURCE_NAMES + ")/" + UUID + ")\"&gt;");
+			.compile("&lt;reference value=\"((" + RESOURCE_NAMES + ")/" + UUID + ")\"/&gt;");
 	private static final Pattern JSON_REFERENCE_UUID_PATTERN = Pattern
 			.compile("\"reference\": \"((" + RESOURCE_NAMES + ")/" + UUID + ")\",");
 	private static final Pattern XML_ID_UUID_AND_VERSION_PATTERN = Pattern.compile(


### PR DESCRIPTION
Fixes regression bug, reference uuid links in xml now working again:  
After adding the xml simplification step, the pattern for references to local resource needed to be changed and was missed. This adds the missing slash to the regex pattern.

closes #331