### PR TITLE
Issues/349 add fhir validation dependencies

### DIFF
--- a/dsf-bpe/dsf-bpe-process-base/pom.xml
+++ b/dsf-bpe/dsf-bpe-process-base/pom.xml
@@ -19,6 +19,10 @@
 			<groupId>org.highmed.dsf</groupId>
 			<artifactId>dsf-fhir-auth</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.highmed.dsf</groupId>
+			<artifactId>dsf-fhir-validation</artifactId>
+		</dependency>
 
 		<dependency>
 			<groupId>org.highmed.dsf</groupId>
@@ -57,6 +61,10 @@
 			<artifactId>spring-context</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-web</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.camunda.bpm</groupId>
 			<artifactId>camunda-engine</artifactId>
 		</dependency>
@@ -65,11 +73,18 @@
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-compress</artifactId>
+		</dependency>
 
 		<dependency>
 			<groupId>de.hs-heilbronn.mi</groupId>
 			<artifactId>log4j2-utils</artifactId>
-			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>jul-to-slf4j</artifactId>
 		</dependency>
 	</dependencies>
 

--- a/dsf-fhir/dsf-fhir-validation/src/main/java/org/highmed/dsf/fhir/validation/SnapshotGenerator.java
+++ b/dsf-fhir/dsf-fhir-validation/src/main/java/org/highmed/dsf/fhir/validation/SnapshotGenerator.java
@@ -1,5 +1,7 @@
 package org.highmed.dsf.fhir.validation;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.hl7.fhir.r4.model.StructureDefinition;
@@ -7,15 +9,16 @@ import org.hl7.fhir.utilities.validation.ValidationMessage;
 
 public interface SnapshotGenerator
 {
-	class SnapshotWithValidationMessages
+	public class SnapshotWithValidationMessages
 	{
 		private final StructureDefinition snapshot;
-		private final List<ValidationMessage> messages;
+		private final List<ValidationMessage> messages = new ArrayList<>();
 
-		SnapshotWithValidationMessages(StructureDefinition snapshot, List<ValidationMessage> messages)
+		public SnapshotWithValidationMessages(StructureDefinition snapshot, List<ValidationMessage> messages)
 		{
 			this.snapshot = snapshot;
-			this.messages = messages;
+			if (messages != null)
+				this.messages.addAll(messages);
 		}
 
 		public StructureDefinition getSnapshot()
@@ -25,7 +28,7 @@ public interface SnapshotGenerator
 
 		public List<ValidationMessage> getMessages()
 		{
-			return messages;
+			return Collections.unmodifiableList(messages);
 		}
 	}
 

--- a/dsf-fhir/dsf-fhir-validation/src/main/java/org/highmed/dsf/fhir/validation/SnapshotGeneratorImpl.java
+++ b/dsf-fhir/dsf-fhir-validation/src/main/java/org/highmed/dsf/fhir/validation/SnapshotGeneratorImpl.java
@@ -26,7 +26,7 @@ public class SnapshotGeneratorImpl implements SnapshotGenerator
 		worker = createWorker(fhirContext, validationSupport);
 	}
 
-	protected HapiWorkerContext createWorker(FhirContext context, IValidationSupport validationSupport)
+	protected IWorkerContext createWorker(FhirContext context, IValidationSupport validationSupport)
 	{
 		HapiWorkerContext workerContext = new HapiWorkerContext(context, validationSupport);
 		workerContext.setLocale(context.getLocalizer().getLocale());


### PR DESCRIPTION
* adds java dependencies to dsf-bpe-process-base, making implementation of FHIR validation within process plugins easier
* improves extensibility of the StructureDefinition snapshot generator classes

closes #349 