### PR TITLE
Issues/350 alternative business keys

### DIFF
--- a/dsf-bpe/dsf-bpe-process-base/src/main/java/org/highmed/dsf/bpe/ConstantsBase.java
+++ b/dsf-bpe/dsf-bpe-process-base/src/main/java/org/highmed/dsf/bpe/ConstantsBase.java
@@ -15,6 +15,7 @@ public interface ConstantsBase
 	String BPMN_EXECUTION_VARIABLE_QUERY_PARAMETERS = "queryParameters";
 	String BPMN_EXECUTION_VARIABLE_TTP_IDENTIFIER = "ttpIdentifier";
 	String BPMN_EXECUTION_VARIABLE_LEADING_MEDIC_IDENTIFIER = "leadingMedicIdentifier";
+	String BPMN_EXECUTION_VARIABLE_ALTERNATIVE_BUSINESS_KEY = "alternativeBusinessKey";
 
 	/**
 	 * Used to distinguish if I am at the moment in a process called by another process by a CallActivity or not

--- a/dsf-bpe/dsf-bpe-process-base/src/main/java/org/highmed/dsf/fhir/task/AbstractTaskMessageSend.java
+++ b/dsf-bpe/dsf-bpe-process-base/src/main/java/org/highmed/dsf/fhir/task/AbstractTaskMessageSend.java
@@ -1,5 +1,6 @@
 package org.highmed.dsf.fhir.task;
 
+import static org.highmed.dsf.bpe.ConstantsBase.BPMN_EXECUTION_VARIABLE_ALTERNATIVE_BUSINESS_KEY;
 import static org.highmed.dsf.bpe.ConstantsBase.BPMN_EXECUTION_VARIABLE_INSTANTIATES_URI;
 import static org.highmed.dsf.bpe.ConstantsBase.BPMN_EXECUTION_VARIABLE_MESSAGE_NAME;
 import static org.highmed.dsf.bpe.ConstantsBase.BPMN_EXECUTION_VARIABLE_PROFILE;
@@ -14,6 +15,7 @@ import static org.highmed.dsf.bpe.ConstantsBase.NAMINGSYSTEM_HIGHMED_ORGANIZATIO
 
 import java.util.Date;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.stream.Stream;
 
 import org.camunda.bpm.engine.delegate.DelegateExecution;
@@ -277,6 +279,35 @@ public class AbstractTaskMessageSend extends AbstractServiceDelegate implements 
 	protected Stream<ParameterComponent> getAdditionalInputParameters(DelegateExecution execution)
 	{
 		return Stream.empty();
+	}
+
+	/**
+	 * Generates an alternative business-key and stores it as a process variable with name
+	 * {@link ConstantsBase#BPMN_EXECUTION_VARIABLE_ALTERNATIVE_BUSINESS_KEY}<br>
+	 * <br>
+	 * <i>Use this method in combination with overriding
+	 * {@link #sendTask(Target, String, String, String, String, Stream)} to use an alternative business-key with the
+	 * communication target.</i>
+	 *
+	 * <pre>
+	 * &#64;Override
+	 * protected void sendTask(Target target, String instantiatesUri, String messageName, String businessKey,
+	 * 		String profile, Stream&lt;ParameterComponent&gt; additionalInputParameters)
+	 * {
+	 * 	String alternativeBusinesKey = createAndSaveAlternativeBusinessKey();
+	 * 	super.sendTask(target, instantiatesUri, messageName, alternativeBusinesKey, profile,
+	 * 			additionalInputParameters);
+	 * }
+	 * </pre>
+	 *
+	 * @return the alternative business-key stored as variable
+	 *         {@link ConstantsBase#BPMN_EXECUTION_VARIABLE_ALTERNATIVE_BUSINESS_KEY}
+	 */
+	protected final String createAndSaveAlternativeBusinessKey()
+	{
+		String alternativeBusinessKey = UUID.randomUUID().toString();
+		execution.setVariable(BPMN_EXECUTION_VARIABLE_ALTERNATIVE_BUSINESS_KEY, alternativeBusinessKey);
+		return alternativeBusinessKey;
 	}
 
 	protected void sendTask(Target target, String instantiatesUri, String messageName, String businessKey,

--- a/dsf-fhir/dsf-fhir-validation/src/main/java/org/highmed/dsf/fhir/validation/SnapshotGeneratorImpl.java
+++ b/dsf-fhir/dsf-fhir-validation/src/main/java/org/highmed/dsf/fhir/validation/SnapshotGeneratorImpl.java
@@ -65,7 +65,7 @@ public class SnapshotGeneratorImpl implements SnapshotGenerator
 					differential.getIdElement().getIdPart(), differential.getUrl(), differential.getVersion());
 		else
 		{
-			logger.warn("Snapshot not generated for StructureDefinition with id {}, url {}, version {}",
+			logger.warn("Snapshot generated with issues for StructureDefinition with id {}, url {}, version {}",
 					differential.getIdElement().getIdPart(), differential.getUrl(), differential.getVersion());
 			messages.forEach(m -> logger.warn("Issue while generating snapshot: {} - {} - {}", m.getDisplay(),
 					m.getLine(), m.getMessage()));


### PR DESCRIPTION
New mechanism to correlate process instances with an alternative business-key

The new method createAndSaveAlternativeBusinessKey() in AbstractTaskMessageSend enables processes to create an alternative business key before sending a task to a target. A return task from the target with the alternative business key is correlated to the original process instance.

closes #350 