### PR TITLE
adds mechanism to disable literal external reference checks

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -25,7 +25,7 @@ preferred-citation:
   type: proceedings
 title: "HiGHmed Data Sharing Framework (HiGHmed DSF)"
 version: 0.7.0
-date-released: 2022-06-12
+date-released: 2022-06-20
 url: https://github.com/highmed/highmed-dsf/wiki
 repository-code: https://github.com/highmed/highmed-dsf
 repository-artifact: https://github.com/highmed/highmed-dsf/releases

--- a/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/dao/command/CheckReferencesCommand.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/dao/command/CheckReferencesCommand.java
@@ -2,6 +2,7 @@ package org.highmed.dsf.fhir.dao.command;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.EnumSet;
 import java.util.Map;
 
 import javax.ws.rs.WebApplicationException;
@@ -14,23 +15,36 @@ import org.highmed.dsf.fhir.help.ResponseGenerator;
 import org.highmed.dsf.fhir.prefer.PreferReturnType;
 import org.highmed.dsf.fhir.service.ReferenceExtractor;
 import org.highmed.dsf.fhir.service.ReferenceResolver;
+import org.highmed.dsf.fhir.service.ResourceReference;
+import org.highmed.dsf.fhir.service.ResourceReference.ReferenceType;
 import org.highmed.dsf.fhir.validation.SnapshotGenerator;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
+import org.hl7.fhir.r4.model.Bundle.HTTPVerb;
 import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.Resource;
+import org.hl7.fhir.r4.model.Task;
+import org.hl7.fhir.r4.model.Task.TaskStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class CheckReferencesCommand<R extends Resource, D extends ResourceDao<R>>
 		extends AbstractCommandWithResource<R, D> implements Command
 {
+	private static final Logger logger = LoggerFactory.getLogger(CheckReferencesCommand.class);
+
+	private final HTTPVerb verb;
+
 	public CheckReferencesCommand(int index, User user, PreferReturnType returnType, Bundle bundle,
-			BundleEntryComponent entry, String serverBase, AuthorizationHelper authorizationHelper, R resource, D dao,
-			ExceptionHandler exceptionHandler, ParameterConverter parameterConverter,
+			BundleEntryComponent entry, String serverBase, AuthorizationHelper authorizationHelper, R resource,
+			HTTPVerb verb, D dao, ExceptionHandler exceptionHandler, ParameterConverter parameterConverter,
 			ResponseGenerator responseGenerator, ReferenceExtractor referenceExtractor,
 			ReferenceResolver referenceResolver)
 	{
 		super(4, index, user, returnType, bundle, entry, serverBase, authorizationHelper, resource, dao,
 				exceptionHandler, parameterConverter, responseGenerator, referenceExtractor, referenceResolver);
+
+		this.verb = verb;
 	}
 
 	@Override
@@ -38,6 +52,31 @@ public class CheckReferencesCommand<R extends Resource, D extends ResourceDao<R>
 			ValidationHelper validationHelper, SnapshotGenerator snapshotGenerator)
 			throws SQLException, WebApplicationException
 	{
-		referencesHelper.checkReferences(idTranslationTable, connection);
+		referencesHelper.checkReferences(idTranslationTable, connection, this::checkReferenceAfterUpdate);
+	}
+
+	// See also TaskServiceImpl#checkReferenceAfterUpdate
+	// See also AbstractResourceServiceImpl#checkReferenceAfterUpdate
+	// See also AbstractResourceServiceImpl#checkReferenceAfterCreate
+	private boolean checkReferenceAfterUpdate(ResourceReference ref)
+	{
+		if (resource instanceof Task && HTTPVerb.PUT.equals(verb))
+		{
+			Task task = (Task) resource;
+			if (EnumSet.of(TaskStatus.COMPLETED, TaskStatus.FAILED).contains(task.getStatus()))
+			{
+				ReferenceType refType = ref.getType(serverBase);
+				if ("Task.input".equals(ref.getLocation()) && ReferenceType.LITERAL_EXTERNAL.equals(refType))
+				{
+					logger.warn("Skipping check of {} reference '{}' at {} in resource with {}, version {}", refType,
+							ref.getReference().getReference(), "Task.input", resource.getIdElement().getIdPart(),
+							// we are checking against the pre-update resource
+							resource.getIdElement().getVersionIdPartAsLong() + 1);
+					return false;
+				}
+			}
+		}
+
+		return true;
 	}
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/dao/command/ReferencesHelper.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/dao/command/ReferencesHelper.java
@@ -2,9 +2,11 @@ package org.highmed.dsf.fhir.dao.command;
 
 import java.sql.Connection;
 import java.util.Map;
+import java.util.function.Predicate;
 
 import javax.ws.rs.WebApplicationException;
 
+import org.highmed.dsf.fhir.service.ResourceReference;
 import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.Resource;
 
@@ -15,5 +17,6 @@ public interface ReferencesHelper<R extends Resource>
 
 	void resolveLogicalReferences(Connection connection) throws WebApplicationException;
 
-	void checkReferences(Map<String, IdType> idTranslationTable, Connection connection) throws WebApplicationException;
+	void checkReferences(Map<String, IdType> idTranslationTable, Connection connection,
+			Predicate<ResourceReference> checkReference) throws WebApplicationException;
 }

--- a/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/dao/command/ReferencesHelperImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/dao/command/ReferencesHelperImpl.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 import javax.ws.rs.WebApplicationException;
@@ -203,10 +204,10 @@ public final class ReferencesHelperImpl<R extends Resource> implements Reference
 	}
 
 	@Override
-	public void checkReferences(Map<String, IdType> idTranslationTable, Connection connection)
-			throws WebApplicationException
+	public void checkReferences(Map<String, IdType> idTranslationTable, Connection connection,
+			Predicate<ResourceReference> checkReference) throws WebApplicationException
 	{
-		referenceExtractor.getReferences(resource)
+		referenceExtractor.getReferences(resource).filter(checkReference)
 				.filter(ref -> referenceResolver.referenceCanBeChecked(ref, connection)).forEach(ref ->
 				{
 					Optional<OperationOutcome> outcome = checkReference(idTranslationTable, connection, ref);

--- a/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/dao/jdbc/AbstractResourceDaoJdbc.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/dao/jdbc/AbstractResourceDaoJdbc.java
@@ -846,7 +846,7 @@ abstract class AbstractResourceDaoJdbc<R extends Resource> implements ResourceDa
 		if (json == null)
 			return;
 
-		JsonArray array = (JsonArray) new JsonParser().parse(json);
+		JsonArray array = (JsonArray) JsonParser.parseString(json);
 
 		Iterator<JsonElement> it = array.iterator();
 		while (it.hasNext())

--- a/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/webservice/impl/TaskServiceImpl.java
+++ b/dsf-fhir/dsf-fhir-server/src/main/java/org/highmed/dsf/fhir/webservice/impl/TaskServiceImpl.java
@@ -1,5 +1,7 @@
 package org.highmed.dsf.fhir.webservice.impl;
 
+import java.util.EnumSet;
+
 import org.highmed.dsf.fhir.authorization.AuthorizationRuleProvider;
 import org.highmed.dsf.fhir.dao.TaskDao;
 import org.highmed.dsf.fhir.event.EventGenerator;
@@ -11,12 +13,19 @@ import org.highmed.dsf.fhir.history.HistoryService;
 import org.highmed.dsf.fhir.service.ReferenceCleaner;
 import org.highmed.dsf.fhir.service.ReferenceExtractor;
 import org.highmed.dsf.fhir.service.ReferenceResolver;
+import org.highmed.dsf.fhir.service.ResourceReference;
+import org.highmed.dsf.fhir.service.ResourceReference.ReferenceType;
 import org.highmed.dsf.fhir.validation.ResourceValidator;
 import org.highmed.dsf.fhir.webservice.specification.TaskService;
 import org.hl7.fhir.r4.model.Task;
+import org.hl7.fhir.r4.model.Task.TaskStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TaskServiceImpl extends AbstractResourceServiceImpl<TaskDao, Task> implements TaskService
 {
+	private static final Logger logger = LoggerFactory.getLogger(TaskServiceImpl.class);
+
 	public TaskServiceImpl(String path, String serverBase, int defaultPageCount, TaskDao dao,
 			ResourceValidator validator, EventHandler eventHandler, ExceptionHandler exceptionHandler,
 			EventGenerator eventGenerator, ResponseGenerator responseGenerator, ParameterConverter parameterConverter,
@@ -27,5 +36,24 @@ public class TaskServiceImpl extends AbstractResourceServiceImpl<TaskDao, Task> 
 		super(path, Task.class, serverBase, defaultPageCount, dao, validator, eventHandler, exceptionHandler,
 				eventGenerator, responseGenerator, parameterConverter, referenceExtractor, referenceResolver,
 				referenceCleaner, authorizationRuleProvider, historyService);
+	}
+
+	// See also CheckReferencesCommand#checkReferenceAfterUpdate
+	@Override
+	protected boolean checkReferenceAfterUpdate(Task updated, ResourceReference ref)
+	{
+		if (EnumSet.of(TaskStatus.COMPLETED, TaskStatus.FAILED).contains(updated.getStatus()))
+		{
+			ReferenceType refType = ref.getType(serverBase);
+			if ("Task.input".equals(ref.getLocation()) && ReferenceType.LITERAL_EXTERNAL.equals(refType))
+			{
+				logger.warn("Skipping check of {} reference '{}' at {} in resource with {}, version {}", refType,
+						ref.getReference().getReference(), "Task.input", updated.getIdElement().getIdPart(),
+						updated.getIdElement().getVersionIdPart());
+				return false;
+			}
+		}
+
+		return super.checkReferenceAfterUpdate(updated, ref);
 	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 		<jetty.version>9.4.46.v20220331</jetty.version>
 		<jersey.version>2.35</jersey.version>
 		<tyrus.version>1.18</tyrus.version>
-		<spring.version>5.3.20</spring.version>
+		<spring.version>5.3.21</spring.version>
 
 		<hapi.fhir.version>5.1.0</hapi.fhir.version>
 		<hapi.hl7v2.version>2.3</hapi.hl7v2.version>
@@ -342,6 +342,12 @@
 				<artifactId>guava</artifactId>
 				<version>31.1-jre</version>
 			</dependency>
+			<dependency>
+				<groupId>com.google.code.gson</groupId>
+				<artifactId>gson</artifactId>
+				<version>2.9.0</version>
+			</dependency>
+
 
 			<!-- HL7 V2 -->
 			<dependency>


### PR DESCRIPTION
Adds a rule for skipping checks of literal external references in Task.input during updates of Task resources with new status `failed` or `completed`.

closes #357 