### PR TITLE
Mail Service Impl

### DIFF
--- a/dsf-bpe/dsf-bpe-process-base/pom.xml
+++ b/dsf-bpe/dsf-bpe-process-base/pom.xml
@@ -86,6 +86,11 @@
 			<groupId>org.slf4j</groupId>
 			<artifactId>jul-to-slf4j</artifactId>
 		</dependency>
+		
+		<dependency>
+			<groupId>com.sun.mail</groupId>
+			<artifactId>jakarta.mail</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/dsf-bpe/dsf-bpe-process-base/src/main/java/org/highmed/dsf/bpe/service/MailService.java
+++ b/dsf-bpe/dsf-bpe-process-base/src/main/java/org/highmed/dsf/bpe/service/MailService.java
@@ -1,0 +1,34 @@
+package org.highmed.dsf.bpe.service;
+
+import java.nio.charset.StandardCharsets;
+import java.util.function.Consumer;
+
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeBodyPart;
+import javax.mail.internet.MimeMessage;
+
+public interface MailService
+{
+	default void send(String subject, String message)
+	{
+		try
+		{
+			MimeBodyPart body = new MimeBodyPart();
+			body.setText(message, StandardCharsets.UTF_8.displayName());
+
+			send(subject, body);
+		}
+		catch (MessagingException e)
+		{
+			throw new RuntimeException(e);
+		}
+	}
+
+	default void send(String subject, MimeBodyPart body)
+	{
+		send(subject, body, m ->
+		{});
+	}
+
+	void send(String subject, MimeBodyPart body, Consumer<MimeMessage> messageModifier);
+}

--- a/dsf-bpe/dsf-bpe-process-base/src/main/java/org/highmed/dsf/bpe/service/MailService.java
+++ b/dsf-bpe/dsf-bpe-process-base/src/main/java/org/highmed/dsf/bpe/service/MailService.java
@@ -1,22 +1,67 @@
 package org.highmed.dsf.bpe.service;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.function.Consumer;
 
+import javax.mail.Message.RecipientType;
 import javax.mail.MessagingException;
+import javax.mail.internet.AddressException;
+import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeBodyPart;
 import javax.mail.internet.MimeMessage;
 
 public interface MailService
 {
+	/**
+	 * Sends a plain text mail to the BPE wide configured recipients.
+	 *
+	 * @param subject
+	 *            not <code>null</code>
+	 * @param message
+	 *            not <code>null</code>
+	 */
 	default void send(String subject, String message)
+	{
+		send(subject, message, (String) null);
+	}
+
+	/**
+	 * Sends a plain text mail to the given address (<b>to</b>) if not <code>null</code> or the BPE wide configured
+	 * recipients.
+	 *
+	 * @param subject
+	 *            not <code>null</code>
+	 * @param message
+	 *            not <code>null</code>
+	 * @param to
+	 *            BPE wide configured recipients if parameter is <code>null</code>
+	 */
+	default void send(String subject, String message, String to)
+	{
+		send(subject, message, to == null ? null : Collections.singleton(to));
+	}
+
+	/**
+	 * Sends a plain text mail to the given addresses (<b>to</b>) if not <code>null</code> and not empty or the BPE wide
+	 * configured recipients.
+	 *
+	 * @param subject
+	 *            not <code>null</code>
+	 * @param message
+	 *            not <code>null</code>
+	 * @param to
+	 *            BPE wide configured recipients if parameter is <code>null</code> or empty
+	 */
+	default void send(String subject, String message, Collection<String> to)
 	{
 		try
 		{
 			MimeBodyPart body = new MimeBodyPart();
 			body.setText(message, StandardCharsets.UTF_8.displayName());
 
-			send(subject, body);
+			send(subject, body, to);
 		}
 		catch (MessagingException e)
 		{
@@ -24,11 +69,87 @@ public interface MailService
 		}
 	}
 
+	/**
+	 * Sends the given {@link MimeBodyPart} as content of a mail to the BPE wide configured recipients.
+	 *
+	 * @param subject
+	 *            not <code>null</code>
+	 * @param body
+	 *            not <code>null</code>
+	 */
 	default void send(String subject, MimeBodyPart body)
 	{
-		send(subject, body, m ->
-		{});
+		send(subject, body, (String) null);
 	}
 
+	/**
+	 * Sends the given {@link MimeBodyPart} as content of a mail to the given address (<b>to</b>) if not
+	 * <code>null</code> or the BPE wide configured recipients.
+	 *
+	 * @param subject
+	 *            not <code>null</code>
+	 * @param body
+	 *            not <code>null</code>
+	 * @param to
+	 *            BPE wide configured recipients if parameter is <code>null</code>
+	 */
+	default void send(String subject, MimeBodyPart body, String to)
+	{
+		send(subject, body, to == null ? null : Collections.singleton(to));
+	}
+
+	/**
+	 * Sends the given {@link MimeBodyPart} as content of a mail to the given addresses (<b>to</b>) if not
+	 * <code>null</code> and not empty or the BPE wide configured recipients.
+	 *
+	 * @param subject
+	 *            not <code>null</code>
+	 * @param body
+	 *            not <code>null</code>
+	 * @param to
+	 *            BPE wide configured recipients if parameter is <code>null</code> or empty
+	 */
+	default void send(String subject, MimeBodyPart body, Collection<String> to)
+	{
+		if (to == null || to.isEmpty())
+			send(subject, body, (Consumer<MimeMessage>) null);
+		else
+			send(subject, body, m ->
+			{
+				try
+				{
+					m.setRecipients(RecipientType.TO, to.stream().map(t ->
+					{
+						try
+						{
+							return new InternetAddress(t);
+						}
+						catch (AddressException e)
+						{
+							throw new RuntimeException(e);
+						}
+					}).toArray(InternetAddress[]::new));
+
+					m.saveChanges();
+				}
+				catch (MessagingException e)
+				{
+					throw new RuntimeException(e);
+				}
+			});
+	}
+
+	/**
+	 * Sends the given {@link MimeBodyPart} as content of a mail to the BPE wide configured recipients, the
+	 * <b>messageModifier</b> can be used to modify elements of the generated {@link MimeMessage} before it is send to
+	 * the SMTP server.
+	 *
+	 * @param subject
+	 *            not <code>null</code>
+	 * @param body
+	 *            not <code>null</code>
+	 * @param messageModifier
+	 *            may be <code>null</code>
+	 */
 	void send(String subject, MimeBodyPart body, Consumer<MimeMessage> messageModifier);
 }

--- a/dsf-bpe/dsf-bpe-server-jetty/pom.xml
+++ b/dsf-bpe/dsf-bpe-server-jetty/pom.xml
@@ -51,11 +51,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>javax.mail</groupId>
-			<artifactId>mail</artifactId>
-		</dependency>
-
-		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>jul-to-slf4j</artifactId>
 		</dependency>

--- a/dsf-bpe/dsf-bpe-server/pom.xml
+++ b/dsf-bpe/dsf-bpe-server/pom.xml
@@ -146,15 +146,14 @@
 			<groupId>org.bouncycastle</groupId>
 			<artifactId>bcmail-jdk15on</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>de.hs-heilbronn.mi</groupId>
+			<artifactId>log4j2-utils</artifactId>
+		</dependency>
 
 		<dependency>
 			<groupId>de.hs-heilbronn.mi</groupId>
 			<artifactId>db-test-utils</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>de.hs-heilbronn.mi</groupId>
-			<artifactId>log4j2-utils</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/dsf-bpe/dsf-bpe-server/pom.xml
+++ b/dsf-bpe/dsf-bpe-server/pom.xml
@@ -139,6 +139,15 @@
 		</dependency>
 
 		<dependency>
+			<groupId>com.sun.mail</groupId>
+			<artifactId>jakarta.mail</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.bouncycastle</groupId>
+			<artifactId>bcmail-jdk15on</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>de.hs-heilbronn.mi</groupId>
 			<artifactId>db-test-utils</artifactId>
 			<scope>test</scope>

--- a/dsf-bpe/dsf-bpe-server/src/main/java/org/highmed/dsf/bpe/service/LoggingMailService.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/org/highmed/dsf/bpe/service/LoggingMailService.java
@@ -5,10 +5,8 @@ import java.io.IOException;
 import java.util.Properties;
 import java.util.function.Consumer;
 
-import javax.mail.Message.RecipientType;
 import javax.mail.MessagingException;
 import javax.mail.Session;
-import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeBodyPart;
 import javax.mail.internet.MimeMessage;
 import javax.mail.internet.MimeMultipart;
@@ -26,8 +24,6 @@ public class LoggingMailService implements MailService
 		try
 		{
 			MimeMessage mimeMessage = new MimeMessage(Session.getInstance(new Properties()));
-			mimeMessage.setFrom(new InternetAddress("dsf@localhost"));
-			mimeMessage.setRecipient(RecipientType.TO, new InternetAddress("dsf@localhost"));
 			mimeMessage.setSubject(subject);
 			mimeMessage.setContent(new MimeMultipart(body));
 			mimeMessage.saveChanges();

--- a/dsf-bpe/dsf-bpe-server/src/main/java/org/highmed/dsf/bpe/service/LoggingMailService.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/org/highmed/dsf/bpe/service/LoggingMailService.java
@@ -1,0 +1,65 @@
+package org.highmed.dsf.bpe.service;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Properties;
+import java.util.function.Consumer;
+
+import javax.mail.Message.RecipientType;
+import javax.mail.MessagingException;
+import javax.mail.Session;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeBodyPart;
+import javax.mail.internet.MimeMessage;
+import javax.mail.internet.MimeMultipart;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LoggingMailService implements MailService
+{
+	private static final Logger logger = LoggerFactory.getLogger(LoggingMailService.class);
+	private static final Logger mailLogger = LoggerFactory.getLogger("mail-logger");
+
+	private MimeMessage createMimeMessage(String subject, MimeBodyPart body)
+	{
+		try
+		{
+			MimeMessage mimeMessage = new MimeMessage(Session.getInstance(new Properties()));
+			mimeMessage.setFrom(new InternetAddress("dsf@localhost"));
+			mimeMessage.setRecipient(RecipientType.TO, new InternetAddress("dsf@localhost"));
+			mimeMessage.setSubject(subject);
+			mimeMessage.setContent(new MimeMultipart(body));
+			mimeMessage.saveChanges();
+
+			return mimeMessage;
+		}
+		catch (MessagingException e)
+		{
+			throw new RuntimeException(e);
+		}
+	}
+
+	@Override
+	public void send(String subject, MimeBodyPart body, Consumer<MimeMessage> messageModifier)
+	{
+		logger.info("SMTP mail service not configured, see debug log for mail subject / content");
+		try
+		{
+			if (logger.isDebugEnabled() || mailLogger.isInfoEnabled())
+			{
+				MimeMessage message = createMimeMessage(subject, body);
+
+				ByteArrayOutputStream out = new ByteArrayOutputStream();
+				message.writeTo(out);
+
+				logger.debug("Subject: {}, Content: {}", subject, out.toString());
+				mailLogger.info("Subject: {}, Content: {}", subject, out.toString());
+			}
+		}
+		catch (IOException | MessagingException e)
+		{
+			throw new RuntimeException(e);
+		}
+	}
+}

--- a/dsf-bpe/dsf-bpe-server/src/main/java/org/highmed/dsf/bpe/service/SmtpMailService.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/org/highmed/dsf/bpe/service/SmtpMailService.java
@@ -1,0 +1,398 @@
+package org.highmed.dsf.bpe.service;
+
+import java.io.IOException;
+import java.security.Key;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import javax.mail.Authenticator;
+import javax.mail.Message.RecipientType;
+import javax.mail.MessagingException;
+import javax.mail.PasswordAuthentication;
+import javax.mail.Session;
+import javax.mail.Transport;
+import javax.mail.internet.AddressException;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeBodyPart;
+import javax.mail.internet.MimeMessage;
+import javax.mail.internet.MimeMultipart;
+import javax.net.ssl.SSLSocketFactory;
+
+import org.bouncycastle.asn1.ASN1EncodableVector;
+import org.bouncycastle.asn1.cms.AttributeTable;
+import org.bouncycastle.asn1.smime.SMIMECapabilitiesAttribute;
+import org.bouncycastle.asn1.smime.SMIMECapability;
+import org.bouncycastle.asn1.smime.SMIMECapabilityVector;
+import org.bouncycastle.cert.X509CertificateHolder;
+import org.bouncycastle.cert.jcajce.JcaCertStore;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cms.jcajce.JcaSimpleSignerInfoGeneratorBuilder;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.mail.smime.SMIMEException;
+import org.bouncycastle.mail.smime.SMIMESignedGenerator;
+import org.bouncycastle.operator.OperatorCreationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.InitializingBean;
+
+import de.rwh.utils.crypto.context.SSLContextFactory;
+
+public class SmtpMailService implements MailService, InitializingBean
+{
+	private static final Logger logger = LoggerFactory.getLogger(SmtpMailService.class);
+
+	private final InternetAddress fromAddress;
+	private final InternetAddress[] toAddresses;
+	private final InternetAddress[] toAddressesCc;
+	private final InternetAddress[] replyToAddresses;
+
+	private final Session session;
+	private final SMIMESignedGenerator smimeSignedGenerator;
+
+	/**
+	 * SMTP, non authentication, mails not signed
+	 *
+	 * @param fromAddress
+	 *            not <code>null</code>
+	 * @param toAddresses
+	 *            not <code>null</code>
+	 * @param mailServerHostname
+	 *            not <code>null</code>
+	 * @param mailServerPort
+	 *            not <code>null</code>
+	 */
+	public SmtpMailService(String fromAddress, String[] toAddresses, String mailServerHostname, int mailServerPort)
+	{
+		this(fromAddress, toAddresses, null, null, false, mailServerHostname, mailServerPort, null, null, null, null,
+				null, null, null);
+	}
+
+	/**
+	 * @param fromAddress
+	 *            not <code>null</code>
+	 * @param toAddresses
+	 *            not <code>null</code>
+	 * @param toAddressesCc
+	 *            may be <code>null</code>
+	 * @param replyToAddresses
+	 *            may be <code>null</code>
+	 * @param useSmtps
+	 * @param mailServerHostname
+	 *            not <code>null</code>
+	 * @param mailServerPort
+	 *            <code>&gt;0</code>
+	 * @param mailServerUsername
+	 *            may be <code>null</code>
+	 * @param mailServerPassword
+	 *            may be <code>null</code>
+	 * @param trustStore
+	 *            may be <code>null</code>
+	 * @param keyStore
+	 *            may be <code>null</code>
+	 * @param keyStorePassword
+	 * @param signStore
+	 *            may be <code>null</code>
+	 * @param signStorePassword
+	 */
+	public SmtpMailService(String fromAddress, String[] toAddresses, String[] toAddressesCc, String[] replyToAddresses,
+			boolean useSmtps, String mailServerHostname, int mailServerPort, String mailServerUsername,
+			String mailServerPassword, KeyStore trustStore, KeyStore keyStore, char[] keyStorePassword,
+			KeyStore signStore, char[] signStorePassword)
+	{
+		this.fromAddress = toInternetAddress(fromAddress).orElse(null);
+		this.toAddresses = Arrays.stream(toAddresses != null ? toAddresses : new String[0])
+				.flatMap(s -> toInternetAddress(s).stream()).toArray(InternetAddress[]::new);
+		this.toAddressesCc = Arrays.stream(toAddressesCc != null ? toAddressesCc : new String[0])
+				.flatMap(s -> toInternetAddress(s).stream()).toArray(InternetAddress[]::new);
+		this.replyToAddresses = Arrays.stream(replyToAddresses != null ? replyToAddresses : new String[0])
+				.flatMap(s -> toInternetAddress(s).stream()).toArray(InternetAddress[]::new);
+
+		session = createSession(useSmtps, mailServerHostname, mailServerPort, mailServerUsername, mailServerPassword,
+				trustStore, keyStore, keyStorePassword);
+
+		smimeSignedGenerator = createSmimeSignedGenerator(fromAddress, signStore, signStorePassword);
+	}
+
+	private Optional<InternetAddress> toInternetAddress(String fromAddress)
+	{
+		if (fromAddress == null || fromAddress.isBlank())
+			return Optional.empty();
+
+		try
+		{
+			return Optional.of(new InternetAddress(fromAddress));
+		}
+		catch (AddressException e)
+		{
+			logger.warn("Unable to create {} from {}: {} - {}", InternetAddress.class.getName(), fromAddress,
+					e.getClass().getName(), e.getMessage());
+
+			return Optional.empty();
+		}
+	}
+
+	@Override
+	public void afterPropertiesSet() throws Exception
+	{
+		if (fromAddress == null)
+			throw new IllegalArgumentException("no valid from address configured");
+		if (toAddresses.length == 0)
+			throw new IllegalArgumentException("no valid to addresses configured");
+	}
+
+	private Session createSession(boolean useSmtps, String mailServerHostname, int mailServerPort,
+			String mailServerUsername, String mailServerPassword, KeyStore trustStore, KeyStore keyStore,
+			char[] keyStorePassword)
+	{
+		Properties properties = new Properties();
+
+		Authenticator authenticator = null;
+		if (mailServerUsername != null && mailServerPassword != null)
+		{
+			authenticator = new Authenticator()
+			{
+				@Override
+				protected PasswordAuthentication getPasswordAuthentication()
+				{
+					return new PasswordAuthentication(mailServerUsername, mailServerPassword);
+				}
+			};
+
+			properties.put("mail.smtps.auth", "true");
+		}
+
+		if (useSmtps)
+		{
+			properties.put("mail.smtps.host", mailServerHostname);
+			properties.put("mail.smtps.port", mailServerPort);
+
+			properties.put("mail.transport.protocol", "smtps");
+			properties.put("mail.transport.protocol.rfc822", "smtps");
+		}
+		else
+		{
+			properties.put("mail.smtp.host", mailServerHostname);
+			properties.put("mail.smtp.port", mailServerPort);
+		}
+
+
+		properties.put("mail.smtp.ssl.socketFactory", createSslSocketFactory(trustStore, keyStore, keyStorePassword));
+
+		return Session.getInstance(properties, authenticator);
+	}
+
+	public SSLSocketFactory createSslSocketFactory(KeyStore trustStore, KeyStore keyStore, char[] keyStorePassword)
+	{
+		try
+		{
+			// uses default jvm trust / keys if not configured (respective trustStore/keyStore fields null)
+			return new SSLContextFactory().createSSLContext(trustStore, keyStore, keyStorePassword).getSocketFactory();
+		}
+		catch (UnrecoverableKeyException | KeyManagementException | KeyStoreException | NoSuchAlgorithmException e)
+		{
+			logger.warn("Unable to create custom ssl socket factory: {} - {}", e.getClass().getName(), e.getMessage());
+			throw new RuntimeException(e);
+		}
+	}
+
+	private SMIMESignedGenerator createSmimeSignedGenerator(String fromAddress, KeyStore signStore,
+			char[] signStorePassword)
+	{
+		if (signStore == null)
+			return null;
+
+		try
+		{
+			Optional<Certificate[]> certificates = getFirstCertificateChain(signStore)
+					.filter(hasCertificateForAddress(fromAddress));
+			if (certificates.isEmpty())
+			{
+				logger.warn("Mail signing certificate store has no S/MIME certificate for {}, not signing mails",
+						fromAddress);
+				return null;
+			}
+
+			Optional<PrivateKey> pivateKey = getFirstPrivateKey(signStore, signStorePassword);
+			if (pivateKey.isEmpty())
+			{
+				logger.warn("Mail signing certificate store has private key, not signing mails", fromAddress);
+				return null;
+			}
+
+			Certificate certificate = certificates
+					.flatMap(c -> Stream.of(c).filter(hasSubjectAlternativeNameRfc822Name(fromAddress)).findFirst())
+					.get();
+
+			ASN1EncodableVector signedAttrs = new ASN1EncodableVector();
+			SMIMECapabilityVector caps = new SMIMECapabilityVector();
+			caps.addCapability(SMIMECapability.aES128_CBC);
+			caps.addCapability(SMIMECapability.aES256_CBC);
+			signedAttrs.add(new SMIMECapabilitiesAttribute(caps));
+
+			SMIMESignedGenerator generator = new SMIMESignedGenerator();
+			generator.addSignerInfoGenerator(
+					new JcaSimpleSignerInfoGeneratorBuilder().setProvider(new BouncyCastleProvider())
+							.setSignedAttributeGenerator(new AttributeTable(signedAttrs)).build("SHA256withRSA",
+									pivateKey.get(), new X509CertificateHolder(certificate.getEncoded())));
+			generator.addCertificates(new JcaCertStore(certificates.map(Arrays::asList).get()));
+
+			return generator;
+		}
+		catch (KeyStoreException | CertificateException | OperatorCreationException | IOException e)
+		{
+			throw new RuntimeException(e);
+		}
+	}
+
+	private Optional<Certificate[]> getFirstCertificateChain(KeyStore store) throws KeyStoreException
+	{
+		return Collections.list(store.aliases()).stream().map(getCertificateChain(store)).findFirst();
+	}
+
+	private Function<String, Certificate[]> getCertificateChain(KeyStore store)
+	{
+		return alias ->
+		{
+			try
+			{
+				return store.getCertificateChain(alias);
+			}
+			catch (KeyStoreException e)
+			{
+				throw new RuntimeException(e);
+			}
+		};
+	}
+
+	private Predicate<Certificate[]> hasCertificateForAddress(String address)
+	{
+		return chain -> hasSubjectAlternativeNameRfc822Name(address).test(chain[0]);
+	}
+
+	private Predicate<Certificate> hasSubjectAlternativeNameRfc822Name(String address)
+	{
+		return certificate ->
+		{
+			try
+			{
+				X509CertificateHolder holder = new X509CertificateHolder(certificate.getEncoded());
+				X509Certificate x509Certificate = new JcaX509CertificateConverter().getCertificate(holder);
+				Collection<List<?>> sanCollections = x509Certificate.getSubjectAlternativeNames();
+				if (sanCollections == null)
+					return false;
+				else
+					// first entry SAN type (1 = Rfc822Name), second entry SAN value
+					return sanCollections.stream()
+							.anyMatch(l -> Objects.equals(1, l.get(0)) && Objects.equals(address, l.get(1)));
+			}
+			catch (CertificateException | IOException e)
+			{
+				throw new RuntimeException(e);
+			}
+		};
+	}
+
+	private Optional<PrivateKey> getFirstPrivateKey(KeyStore store, char[] keyPassword) throws KeyStoreException
+	{
+		return Collections.list(store.aliases()).stream().map(getPrivateKey(store, keyPassword)).findFirst()
+				.filter(k -> k instanceof PrivateKey).map(k -> (PrivateKey) k);
+	}
+
+	private Function<String, Key> getPrivateKey(KeyStore store, char[] keyPassword)
+	{
+		return alias ->
+		{
+			try
+			{
+				return store.getKey(alias, keyPassword);
+			}
+			catch (UnrecoverableKeyException | KeyStoreException | NoSuchAlgorithmException e)
+			{
+				throw new RuntimeException(e);
+			}
+		};
+	}
+
+	private MimeMessage createMimeMessage(String subject, MimeMultipart mimeMultipart)
+	{
+		try
+		{
+			MimeMessage mimeMessage = new MimeMessage(session);
+			mimeMessage.setFrom(fromAddress);
+			mimeMessage.setRecipients(RecipientType.TO, toAddresses);
+			mimeMessage.setRecipients(RecipientType.CC, toAddressesCc);
+			mimeMessage.setReplyTo(replyToAddresses);
+			mimeMessage.setSubject(subject);
+			mimeMessage.setContent(mimeMultipart);
+			mimeMessage.saveChanges();
+
+			return mimeMessage;
+		}
+		catch (MessagingException e)
+		{
+			throw new RuntimeException(e);
+		}
+	}
+
+	private MimeMultipart signMessage(MimeBodyPart body)
+	{
+		if (smimeSignedGenerator != null)
+		{
+			try
+			{
+				return smimeSignedGenerator.generate(body);
+			}
+			catch (SMIMEException e)
+			{
+				throw new RuntimeException(e);
+			}
+		}
+		else
+		{
+			try
+			{
+				return new MimeMultipart(body);
+			}
+			catch (MessagingException e)
+			{
+				throw new RuntimeException(e);
+			}
+		}
+	}
+
+	@Override
+	public void send(String subject, MimeBodyPart body, Consumer<MimeMessage> messageModifier)
+	{
+		MimeMessage message = createMimeMessage(subject, signMessage(body));
+
+		messageModifier.accept(message);
+
+		try
+		{
+			Transport.send(message);
+		}
+		catch (MessagingException e)
+		{
+			logger.warn("Unable to send message: {} - {}", e.getClass().getName(), e.getMessage());
+			throw new RuntimeException(e);
+		}
+	}
+}

--- a/dsf-bpe/dsf-bpe-server/src/main/java/org/highmed/dsf/bpe/service/SmtpMailService.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/org/highmed/dsf/bpe/service/SmtpMailService.java
@@ -182,21 +182,15 @@ public class SmtpMailService implements MailService, InitializingBean
 		if (useSmtps)
 		{
 			properties.put("mail.smtp.ssl.enable", "true");
-			properties.put("mail.smtp.host", mailServerHostname);
-			properties.put("mail.smtp.port", mailServerPort);
-
 			properties.put("mail.transport.protocol", "smtps");
 			properties.put("mail.smtp.socketFactory.fallback", "false");
-
 			properties.put("mail.smtp.ssl.checkserveridentity", "true");
 			properties.put("mail.smtp.ssl.socketFactory",
 					createSslSocketFactory(trustStore, keyStore, keyStorePassword));
 		}
-		else
-		{
-			properties.put("mail.smtp.host", mailServerHostname);
-			properties.put("mail.smtp.port", mailServerPort);
-		}
+
+		properties.put("mail.smtp.host", mailServerHostname);
+		properties.put("mail.smtp.port", mailServerPort);
 
 		return Session.getInstance(properties, authenticator);
 	}

--- a/dsf-bpe/dsf-bpe-server/src/main/java/org/highmed/dsf/bpe/spring/config/CamundaConfig.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/org/highmed/dsf/bpe/spring/config/CamundaConfig.java
@@ -112,7 +112,7 @@ public class CamundaConfig
 	public SpringProcessEngineConfiguration processEngineConfiguration() throws IOException
 	{
 		var c = new MultiVersionSpringProcessEngineConfiguration(delegateProvider());
-		c.setProcessEngineName("highmed");
+		c.setProcessEngineName("dsf");
 		c.setDataSource(transactionAwareDataSource());
 		c.setTransactionManager(transactionManager());
 		c.setDatabaseSchemaUpdate("false");

--- a/dsf-bpe/dsf-bpe-server/src/main/java/org/highmed/dsf/bpe/spring/config/MailConfig.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/org/highmed/dsf/bpe/spring/config/MailConfig.java
@@ -1,0 +1,173 @@
+package org.highmed.dsf.bpe.spring.config;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.UUID;
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.pkcs.PKCSException;
+import org.highmed.dsf.bpe.service.LoggingMailService;
+import org.highmed.dsf.bpe.service.MailService;
+import org.highmed.dsf.bpe.service.SmtpMailService;
+import org.highmed.dsf.tools.build.BuildInfoReader;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.context.event.EventListener;
+
+import de.rwh.utils.crypto.CertificateHelper;
+import de.rwh.utils.crypto.io.CertificateReader;
+import de.rwh.utils.crypto.io.PemIo;
+
+@Configuration
+public class MailConfig
+{
+	private static final BouncyCastleProvider provider = new BouncyCastleProvider();
+
+	@Autowired
+	private PropertiesConfig propertiesConfig;
+
+	@Autowired
+	BuildInfoReaderConfig buildInfoReaderConfig;
+
+	@Bean
+	public MailService mailService()
+	{
+		if (isConfigured())
+		{
+			try
+			{
+				return newSmptMailService();
+			}
+			catch (IOException | CertificateException | KeyStoreException | NoSuchAlgorithmException | PKCSException e)
+			{
+				throw new RuntimeException(e);
+			}
+		}
+		else
+			return new LoggingMailService();
+	}
+
+	private boolean isConfigured()
+	{
+		return propertiesConfig.getMailServerHostname() != null || propertiesConfig.getMailServerPort() > 0
+				|| propertiesConfig.getMailServerUsername() != null || propertiesConfig.getMailServerPassword() != null;
+	}
+
+	private MailService newSmptMailService()
+			throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException, PKCSException
+	{
+		String fromAddress = propertiesConfig.getMailFromAddress();
+		List<String> toAddresses = propertiesConfig.getMailToAddresses();
+		List<String> toAddressesCc = propertiesConfig.getMailToAddressesCc();
+		List<String> replyToAddresses = propertiesConfig.getMailReplyToAddresses();
+
+		boolean useSmtps = propertiesConfig.getMailUseSmtps();
+
+		String mailServerHostname = propertiesConfig.getMailServerHostname();
+		int mailServerPort = propertiesConfig.getMailServerPort();
+
+		String mailServerUsername = propertiesConfig.getMailServerUsername();
+		char[] mailServerPassword = propertiesConfig.getMailServerPassword();
+
+		KeyStore trustStore = toTrustStore(propertiesConfig.getMailServerTrustStoreFile());
+		char[] keyStorePassword = UUID.randomUUID().toString().toCharArray();
+		KeyStore keyStore = toKeyStore(propertiesConfig.getMailServerClientCertificateFile(),
+				propertiesConfig.getMailServerClientCertificatePrivateKeyFile(),
+				propertiesConfig.getMailServerClientCertificatePrivateKeyFilePassword(), keyStorePassword);
+
+		KeyStore signStore = toSmimeSigningStore(propertiesConfig.getMailSmimeSigingKeyStoreFile(),
+				propertiesConfig.getMailSmimeSigingKeyStorePassword());
+
+		return new SmtpMailService(fromAddress, toAddresses, toAddressesCc, replyToAddresses, useSmtps,
+				mailServerHostname, mailServerPort, mailServerUsername, mailServerPassword, trustStore, keyStore,
+				keyStorePassword, signStore, propertiesConfig.getMailSmimeSigingKeyStorePassword());
+	}
+
+	private KeyStore toTrustStore(String trustStoreFile)
+			throws IOException, NoSuchAlgorithmException, CertificateException, KeyStoreException
+	{
+		if (trustStoreFile == null)
+			return null;
+
+		Path trustStorePath = Paths.get(trustStoreFile);
+
+		if (!Files.isReadable(trustStorePath))
+			throw new IOException("Mail server trust store file '" + trustStorePath.toString() + "' not readable");
+
+		return CertificateReader.allFromCer(trustStorePath);
+	}
+
+	private KeyStore toKeyStore(String certificateFile, String privateKeyFile, char[] privateKeyPassword,
+			char[] keyStorePassword)
+			throws IOException, CertificateException, PKCSException, KeyStoreException, NoSuchAlgorithmException
+	{
+		if (certificateFile == null && privateKeyFile == null)
+			return null;
+
+		Path certificatePath = Paths.get(certificateFile);
+		Path privateKeyPath = Paths.get(privateKeyFile);
+
+		if (!Files.isReadable(certificatePath))
+			throw new IOException(
+					"Mail server client certificate file '" + certificatePath.toString() + "' not readable");
+		if (!Files.isReadable(certificatePath))
+			throw new IOException(
+					"Mail server client certificate private key file '" + privateKeyPath.toString() + "' not readable");
+
+		X509Certificate certificate = PemIo.readX509CertificateFromPem(certificatePath);
+		PrivateKey privateKey = PemIo.readPrivateKeyFromPem(provider, privateKeyPath, privateKeyPassword);
+
+		String subjectCommonName = CertificateHelper.getSubjectCommonName(certificate);
+		return CertificateHelper.toJksKeyStore(privateKey, new Certificate[] { certificate }, subjectCommonName,
+				keyStorePassword);
+	}
+
+	private KeyStore toSmimeSigningStore(String mailSmimeSigingKeyStoreFile, char[] mailSmimeSigingKeyStorePassword)
+			throws IOException, KeyStoreException, CertificateException, NoSuchAlgorithmException
+	{
+		if (mailSmimeSigingKeyStoreFile == null)
+			return null;
+
+		Path keyStorePath = Paths.get(mailSmimeSigingKeyStoreFile);
+
+		if (!Files.isReadable(keyStorePath))
+			throw new IOException(
+					"S/MIME mail signing certificate file '" + keyStorePath.toString() + "' not readable");
+
+		return CertificateReader.fromPkcs12(keyStorePath, mailSmimeSigingKeyStorePassword);
+	}
+
+	@EventListener({ ContextRefreshedEvent.class })
+	public void onContextRefreshedEvent(ContextRefreshedEvent event) throws IOException
+	{
+		if (propertiesConfig.getMailSendTestMailOnStartup())
+		{
+			BuildInfoReader buildInfoReader = buildInfoReaderConfig.buildInfoReader();
+			mailService().send("DSF Test Mail",
+					"DSF startup test mail from BPE {" + "artifact: " + buildInfoReader.getProjectArtifact()
+							+ ", version: " + buildInfoReader.getProjectVersion() + ", build: "
+							+ buildInfoReader.getBuildDate().withZoneSameInstant(ZoneId.systemDefault())
+									.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+							+ ", branch: " + buildInfoReader.getBuildBranch() + ", commit: "
+							+ buildInfoReader.getBuildNumber() + "} send on "
+							+ ZonedDateTime.now().withZoneSameInstant(ZoneId.systemDefault())
+									.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+							+ ".");
+		}
+	}
+}

--- a/dsf-bpe/dsf-bpe-server/src/main/java/org/highmed/dsf/bpe/spring/config/PropertiesConfig.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/org/highmed/dsf/bpe/spring/config/PropertiesConfig.java
@@ -234,9 +234,17 @@ public class PropertiesConfig
 	@Value("${org.highmed.dsf.bpe.mail.smime.p12Keystore.password:#{null}}")
 	private char[] mailSmimeSigingKeyStorePassword;
 
-	@Documentation(description = "To enable a test mail being send on startup of the BPE, set to `true`")
+	@Documentation(description = "To enable a test mail being send on startup of the BPE, set to `true`. Requires SMTP server to be configured.")
 	@Value("${org.highmed.dsf.bpe.mail.sendTestMailOnStartup:false}")
-	private boolean mailSendTestMailOnStartup;
+	private boolean sendTestMailOnStartup;
+
+	@Documentation(description = "To enable mails being send for every ERROR logged, set to `true`. Requires SMTP server to be configured.")
+	@Value("${org.highmed.dsf.bpe.mail.sendMailOnErrorLogEvent:false}")
+	private boolean sendMailOnErrorLogEvent;
+
+	@Documentation(description = "Number of previous INFO, WARN log messages to include in ERROR log event mails (>=0). Requires send mail on ERROR log event option to be enabled.")
+	@Value("${org.highmed.dsf.bpe.mail.mailOnErrorLogEventBufferSize:4}")
+	private int mailOnErrorLogEventBufferSize;
 
 	@Bean // static in order to initialize before @Configuration classes
 	public static PropertySourcesPlaceholderConfigurer propertySourcesPlaceholderConfigurer(
@@ -517,8 +525,18 @@ public class PropertiesConfig
 		return mailSmimeSigingKeyStorePassword;
 	}
 
-	public boolean getMailSendTestMailOnStartup()
+	public boolean getSendTestMailOnStartup()
 	{
-		return mailSendTestMailOnStartup;
+		return sendTestMailOnStartup;
+	}
+
+	public boolean getSendMailOnErrorLogEvent()
+	{
+		return sendMailOnErrorLogEvent;
+	}
+
+	public int getMailOnErrorLogEventBufferSize()
+	{
+		return mailOnErrorLogEventBufferSize;
 	}
 }

--- a/dsf-bpe/dsf-bpe-server/src/main/java/org/highmed/dsf/bpe/spring/config/PropertiesConfig.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/org/highmed/dsf/bpe/spring/config/PropertiesConfig.java
@@ -235,7 +235,7 @@ public class PropertiesConfig
 	private char[] mailSmimeSigingKeyStorePassword;
 
 	@Documentation(description = "To enable a test mail being send on startup of the BPE, set to `true`")
-	@Value("${org.highmed.dsf.bpe.mail.sendTestMailOnStartup:true}")
+	@Value("${org.highmed.dsf.bpe.mail.sendTestMailOnStartup:false}")
 	private boolean mailSendTestMailOnStartup;
 
 	@Bean // static in order to initialize before @Configuration classes

--- a/dsf-bpe/dsf-bpe-server/src/main/java/org/highmed/dsf/bpe/spring/config/PropertiesConfig.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/org/highmed/dsf/bpe/spring/config/PropertiesConfig.java
@@ -175,11 +175,11 @@ public class PropertiesConfig
 	private long fhirServerRetryDelayMillis;
 
 	@Documentation(description = "Mail service sender address", example = "sender@localhost")
-	@Value("${org.highmed.dsf.bpe.mail.fromAddress:dsf@localhost}")
+	@Value("${org.highmed.dsf.bpe.mail.fromAddress:}")
 	private String mailFromAddress;
 
 	@Documentation(description = "Mail service recipient addresses, configure at least one; comma or space separated list, YAML block scalars supported", example = "recipient@localhost")
-	@Value("#{'${org.highmed.dsf.bpe.mail.toAddresses:dsf@localhost}'.trim().split('(,[ ]?)|(\\n)')}")
+	@Value("#{'${org.highmed.dsf.bpe.mail.toAddresses:}'.trim().split('(,[ ]?)|(\\n)')}")
 	private List<String> mailToAddresses;
 
 	@Documentation(description = "Mail service CC recipient addresses; comma or space separated list, YAML block scalars supported", example = "cc.recipient@localhost")
@@ -218,7 +218,7 @@ public class PropertiesConfig
 	@Value("${org.highmed.dsf.bpe.mail.client.certificate:#{null}}")
 	private String mailServerClientCertificateFile;
 
-	@Documentation(description = "Prvate key corresponging to the SMTP server client certificate as PEM encoded file. Use ${env_variable}_PASSWORD* or *${env_variable}_PASSWORD_FILE* if private key is encrypted. Requires SMTP over TLS to be enabled via *ORG_HIGHMED_DSF_BPE_MAIL_USESMTPS*", recommendation = "Use docker secret file to configure", example = "/run/secrets/smtp_server_client_certificate_private_key.pem")
+	@Documentation(description = "Private key corresponging to the SMTP server client certificate as PEM encoded file. Use ${env_variable}_PASSWORD* or *${env_variable}_PASSWORD_FILE* if private key is encrypted. Requires SMTP over TLS to be enabled via *ORG_HIGHMED_DSF_BPE_MAIL_USESMTPS*", recommendation = "Use docker secret file to configure", example = "/run/secrets/smtp_server_client_certificate_private_key.pem")
 	@Value("${org.highmed.dsf.bpe.mail.client.certificate.private.key:#{null}}")
 	private String mailServerClientCertificatePrivateKeyFile;
 

--- a/dsf-bpe/dsf-bpe-server/src/main/java/org/highmed/dsf/bpe/spring/config/PropertiesConfig.java
+++ b/dsf-bpe/dsf-bpe-server/src/main/java/org/highmed/dsf/bpe/spring/config/PropertiesConfig.java
@@ -174,6 +174,70 @@ public class PropertiesConfig
 	@Value("${org.highmed.dsf.bpe.process.fhir.server.retry.sleep:5000}")
 	private long fhirServerRetryDelayMillis;
 
+	@Documentation(description = "Mail service sender address", example = "sender@localhost")
+	@Value("${org.highmed.dsf.bpe.mail.fromAddress:dsf@localhost}")
+	private String mailFromAddress;
+
+	@Documentation(description = "Mail service recipient addresses, configure at least one; comma or space separated list, YAML block scalars supported", example = "recipient@localhost")
+	@Value("#{'${org.highmed.dsf.bpe.mail.toAddresses:dsf@localhost}'.trim().split('(,[ ]?)|(\\n)')}")
+	private List<String> mailToAddresses;
+
+	@Documentation(description = "Mail service CC recipient addresses; comma or space separated list, YAML block scalars supported", example = "cc.recipient@localhost")
+	@Value("#{'${org.highmed.dsf.bpe.mail.toAddressesCc:}'.trim().split('(,[ ]?)|(\\n)')}")
+	private List<String> mailToAddressesCc;
+
+	@Documentation(description = "Mail service reply to addresses; comma or space separated list, YAML block scalars supported", example = "reply.to@localhost")
+	@Value("#{'${org.highmed.dsf.bpe.mail.replyToAddresses:}'.trim().split('(,[ ]?)|(\\n)')}")
+	private List<String> mailReplyToAddresses;
+
+	@Documentation(description = "To enable SMTP over TLS (smtps), set to `true`")
+	@Value("${org.highmed.dsf.bpe.mail.useSmtps:false}")
+	private boolean mailUseSmtps;
+
+	@Documentation(description = "SMTP server hostname", example = "smtp.server.de")
+	@Value("${org.highmed.dsf.bpe.mail.host:#{null}}")
+	private String mailServerHostname;
+
+	@Documentation(description = "SMTP server port", example = "465")
+	@Value("${org.highmed.dsf.bpe.mail.port:0}")
+	private int mailServerPort;
+
+	@Documentation(description = "SMTP server authentication username", recommendation = "Configure if the SMTP server reqiures username/password authentication; enable SMTP over TLS via *ORG_HIGHMED_DSF_BPE_MAIL_USESMTPS*")
+	@Value("${org.highmed.dsf.bpe.mail.username:#{null}}")
+	private String mailServerUsername;
+
+	@Documentation(description = "SMTP server authentication password", recommendation = "Configure if the SMTP server reqiures username/password authentication; use docker secret file to configure using *${env_variable}_FILE*; enable SMTP over TLS via *ORG_HIGHMED_DSF_BPE_MAIL_USESMTPS*")
+	@Value("${org.highmed.dsf.bpe.mail.password:#{null}}")
+	private char[] mailServerPassword;
+
+	@Documentation(description = "PEM encoded file with one or more trusted root certificates to validate the server certificate of the SMTP server. Requires SMTP over TLS to be enabled via *ORG_HIGHMED_DSF_BPE_MAIL_USESMTPS*", recommendation = "Use docker secret file to configure", example = "/run/secrets/smtp_server_trust_certificates.pem")
+	@Value("${org.highmed.dsf.bpe.mail.trust.certificates:#{null}}")
+	private String mailServerTrustStoreFile;
+
+	@Documentation(description = "PEM encoded file with client certificate used to authenticate against the SMTP server. Requires SMTP over TLS to be enabled via *ORG_HIGHMED_DSF_BPE_MAIL_USESMTPS*", recommendation = "Use docker secret file to configure", example = "/run/secrets/smtp_server_client_certificate.pem")
+	@Value("${org.highmed.dsf.bpe.mail.client.certificate:#{null}}")
+	private String mailServerClientCertificateFile;
+
+	@Documentation(description = "Prvate key corresponging to the SMTP server client certificate as PEM encoded file. Use ${env_variable}_PASSWORD* or *${env_variable}_PASSWORD_FILE* if private key is encrypted. Requires SMTP over TLS to be enabled via *ORG_HIGHMED_DSF_BPE_MAIL_USESMTPS*", recommendation = "Use docker secret file to configure", example = "/run/secrets/smtp_server_client_certificate_private_key.pem")
+	@Value("${org.highmed.dsf.bpe.mail.client.certificate.private.key:#{null}}")
+	private String mailServerClientCertificatePrivateKeyFile;
+
+	@Documentation(description = "Password to decrypt the local client certificate encrypted private key", recommendation = "Use docker secret file to configure using *${env_variable}_FILE*", example = "/run/secrets/smtp_server_client_certificate_private_key.pem.password")
+	@Value("${org.highmed.dsf.bpe.mail.client.certificate.private.key.password:#{null}}")
+	private char[] mailServerClientCertificatePrivateKeyFilePassword;
+
+	@Documentation(description = "PKCS12 encoded file with S/MIME certificate, private key and certificate chain to enable send mails to be S/MIME signed", recommendation = "Use docker secret file to configure", example = "/run/secrets/smime_certificate.p12")
+	@Value("${org.highmed.dsf.bpe.mail.smime.p12Keystore:#{null}}")
+	private String mailSmimeSigingKeyStoreFile;
+
+	@Documentation(description = "Password to decrypt the PKCS12 encoded S/MIMIE certificate file", recommendation = "Use docker secret file to configure using *${env_variable}_FILE*", example = "/run/secrets/smime_certificate.p12.password")
+	@Value("${org.highmed.dsf.bpe.mail.smime.p12Keystore.password:#{null}}")
+	private char[] mailSmimeSigingKeyStorePassword;
+
+	@Documentation(description = "To enable a test mail being send on startup of the BPE, set to `true`")
+	@Value("${org.highmed.dsf.bpe.mail.sendTestMailOnStartup:true}")
+	private boolean mailSendTestMailOnStartup;
+
 	@Bean // static in order to initialize before @Configuration classes
 	public static PropertySourcesPlaceholderConfigurer propertySourcesPlaceholderConfigurer(
 			ConfigurableEnvironment environment)
@@ -376,5 +440,85 @@ public class PropertiesConfig
 	public long getFhirServerRetryDelayMillis()
 	{
 		return fhirServerRetryDelayMillis;
+	}
+
+	public String getMailFromAddress()
+	{
+		return mailFromAddress;
+	}
+
+	public List<String> getMailToAddresses()
+	{
+		return mailToAddresses;
+	}
+
+	public List<String> getMailToAddressesCc()
+	{
+		return mailToAddressesCc;
+	}
+
+	public List<String> getMailReplyToAddresses()
+	{
+		return mailReplyToAddresses;
+	}
+
+	public boolean getMailUseSmtps()
+	{
+		return mailUseSmtps;
+	}
+
+	public String getMailServerHostname()
+	{
+		return mailServerHostname;
+	}
+
+	public int getMailServerPort()
+	{
+		return mailServerPort;
+	}
+
+	public String getMailServerUsername()
+	{
+		return mailServerUsername;
+	}
+
+	public char[] getMailServerPassword()
+	{
+		return mailServerPassword;
+	}
+
+	public String getMailServerTrustStoreFile()
+	{
+		return mailServerTrustStoreFile;
+	}
+
+	public String getMailServerClientCertificateFile()
+	{
+		return mailServerClientCertificateFile;
+	}
+
+	public String getMailServerClientCertificatePrivateKeyFile()
+	{
+		return mailServerClientCertificatePrivateKeyFile;
+	}
+
+	public char[] getMailServerClientCertificatePrivateKeyFilePassword()
+	{
+		return mailServerClientCertificatePrivateKeyFilePassword;
+	}
+
+	public String getMailSmimeSigingKeyStoreFile()
+	{
+		return mailSmimeSigingKeyStoreFile;
+	}
+
+	public char[] getMailSmimeSigingKeyStorePassword()
+	{
+		return mailSmimeSigingKeyStorePassword;
+	}
+
+	public boolean getMailSendTestMailOnStartup()
+	{
+		return mailSendTestMailOnStartup;
 	}
 }

--- a/dsf-bpe/dsf-bpe-server/src/test/java/org/highmed/dsf/bpe/service/LoggingMailServiceTest.java
+++ b/dsf-bpe/dsf-bpe-server/src/test/java/org/highmed/dsf/bpe/service/LoggingMailServiceTest.java
@@ -1,0 +1,12 @@
+package org.highmed.dsf.bpe.service;
+
+import org.junit.Test;
+
+public class LoggingMailServiceTest
+{
+	@Test
+	public void testSend() throws Exception
+	{
+		new LoggingMailService().send("subject test", "message test");
+	}
+}

--- a/dsf-bpe/dsf-bpe-server/src/test/java/org/highmed/dsf/bpe/service/SmtpMailServiceTest.java
+++ b/dsf-bpe/dsf-bpe-server/src/test/java/org/highmed/dsf/bpe/service/SmtpMailServiceTest.java
@@ -2,6 +2,7 @@ package org.highmed.dsf.bpe.service;
 
 import java.nio.file.Paths;
 import java.security.KeyStore;
+import java.util.Arrays;
 
 import org.junit.Ignore;
 import org.junit.Test;
@@ -14,16 +15,16 @@ public class SmtpMailServiceTest
 	@Test
 	public void testSend() throws Exception
 	{
-		new SmtpMailService("from@localhost", new String[] { "to@localhost" }, "localhost", 1025).send("test subject",
+		new SmtpMailService("from@localhost", Arrays.asList("to@localhost"), "localhost", 1025).send("test subject",
 				"test message");
 	}
 
 	@Test
 	public void testSendReplyAndCc() throws Exception
 	{
-		new SmtpMailService("from@localhost", new String[] { "to1@localhost", "to2@localhost" },
-				new String[] { "cc1@localhost", "cc2@localhost" },
-				new String[] { "replyTo1@localhost", "replyTo2@localhost" }, false, "localhost", 1025, null, null, null,
+		new SmtpMailService("from@localhost", Arrays.asList("to1@localhost", "to2@localhost"),
+				Arrays.asList("cc1@localhost", "cc2@localhost"),
+				Arrays.asList("replyTo1@localhost", "replyTo2@localhost"), false, "localhost", 1025, null, null, null,
 				null, null, null, null).send("test subject", "test message");
 	}
 
@@ -33,7 +34,24 @@ public class SmtpMailServiceTest
 		char[] signStorePassword = "password".toCharArray();
 		KeyStore signStore = CertificateReader.fromPkcs12(Paths.get("cert.p12"), signStorePassword);
 
-		new SmtpMailService("from@localhost", new String[] { "to@localhost" }, null, null, false, "localhost", 1025,
-				null, null, null, null, null, signStore, signStorePassword).send("test subject", "test message");
+		new SmtpMailService("from@localhost", Arrays.asList("to@localhost"), null, null, false, "localhost", 1025, null,
+				null, null, null, null, signStore, signStorePassword).send("test subject", "test message");
+	}
+
+	@Test
+	public void testSendViaSmtps() throws Exception
+	{
+		KeyStore trustStore = CertificateReader.allFromCer(Paths.get("cert.pem"));
+		new SmtpMailService("from@localhost", Arrays.asList("to@localhost"), null, null, true, "localhost", 465, null,
+				null, trustStore, null, null, null, null).send("test subject", "test message");
+
+	}
+
+	@Test
+	public void testSendViaGmail() throws Exception
+	{
+		new SmtpMailService("foo@gmail.com", Arrays.asList("foo@gmail.com"), null, null, true, "smtp.gmail.com", 465,
+				"foo", "password".toCharArray(), null, null, null, null, null).send("test subject", "test message");
+
 	}
 }

--- a/dsf-bpe/dsf-bpe-server/src/test/java/org/highmed/dsf/bpe/service/SmtpMailServiceTest.java
+++ b/dsf-bpe/dsf-bpe-server/src/test/java/org/highmed/dsf/bpe/service/SmtpMailServiceTest.java
@@ -1,0 +1,39 @@
+package org.highmed.dsf.bpe.service;
+
+import java.nio.file.Paths;
+import java.security.KeyStore;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+import de.rwh.utils.crypto.io.CertificateReader;
+
+@Ignore
+public class SmtpMailServiceTest
+{
+	@Test
+	public void testSend() throws Exception
+	{
+		new SmtpMailService("from@localhost", new String[] { "to@localhost" }, "localhost", 1025).send("test subject",
+				"test message");
+	}
+
+	@Test
+	public void testSendReplyAndCc() throws Exception
+	{
+		new SmtpMailService("from@localhost", new String[] { "to1@localhost", "to2@localhost" },
+				new String[] { "cc1@localhost", "cc2@localhost" },
+				new String[] { "replyTo1@localhost", "replyTo2@localhost" }, false, "localhost", 1025, null, null, null,
+				null, null, null, null).send("test subject", "test message");
+	}
+
+	@Test
+	public void testSendSigned() throws Exception
+	{
+		char[] signStorePassword = "password".toCharArray();
+		KeyStore signStore = CertificateReader.fromPkcs12(Paths.get("cert.p12"), signStorePassword);
+
+		new SmtpMailService("from@localhost", new String[] { "to@localhost" }, null, null, false, "localhost", 1025,
+				null, null, null, null, null, signStore, signStorePassword).send("test subject", "test message");
+	}
+}

--- a/dsf-bpe/dsf-bpe-server/src/test/java/org/highmed/dsf/bpe/service/SmtpMailServiceTest.java
+++ b/dsf-bpe/dsf-bpe-server/src/test/java/org/highmed/dsf/bpe/service/SmtpMailServiceTest.java
@@ -20,12 +20,19 @@ public class SmtpMailServiceTest
 	}
 
 	@Test
+	public void testSendTo() throws Exception
+	{
+		new SmtpMailService("from@localhost", Arrays.asList("to@localhost"), "localhost", 1025).send("test subject",
+				"test message", "to-test@localhost");
+	}
+
+	@Test
 	public void testSendReplyAndCc() throws Exception
 	{
 		new SmtpMailService("from@localhost", Arrays.asList("to1@localhost", "to2@localhost"),
 				Arrays.asList("cc1@localhost", "cc2@localhost"),
 				Arrays.asList("replyTo1@localhost", "replyTo2@localhost"), false, "localhost", 1025, null, null, null,
-				null, null, null, null).send("test subject", "test message");
+				null, null, null, null, false, 0).send("test subject", "test message");
 	}
 
 	@Test
@@ -35,7 +42,7 @@ public class SmtpMailServiceTest
 		KeyStore signStore = CertificateReader.fromPkcs12(Paths.get("cert.p12"), signStorePassword);
 
 		new SmtpMailService("from@localhost", Arrays.asList("to@localhost"), null, null, false, "localhost", 1025, null,
-				null, null, null, null, signStore, signStorePassword).send("test subject", "test message");
+				null, null, null, null, signStore, signStorePassword, false, 0).send("test subject", "test message");
 	}
 
 	@Test
@@ -43,7 +50,7 @@ public class SmtpMailServiceTest
 	{
 		KeyStore trustStore = CertificateReader.allFromCer(Paths.get("cert.pem"));
 		new SmtpMailService("from@localhost", Arrays.asList("to@localhost"), null, null, true, "localhost", 465, null,
-				null, trustStore, null, null, null, null).send("test subject", "test message");
+				null, trustStore, null, null, null, null, false, 0).send("test subject", "test message");
 
 	}
 
@@ -51,7 +58,8 @@ public class SmtpMailServiceTest
 	public void testSendViaGmail() throws Exception
 	{
 		new SmtpMailService("foo@gmail.com", Arrays.asList("foo@gmail.com"), null, null, true, "smtp.gmail.com", 465,
-				"foo", "password".toCharArray(), null, null, null, null, null).send("test subject", "test message");
+				"foo", "password".toCharArray(), null, null, null, null, null, false, 0)
+				.send("test subject", "test message");
 
 	}
 }

--- a/dsf-docker-test-setup-3medic-ttp-docker/docker-compose.yml
+++ b/dsf-docker-test-setup-3medic-ttp-docker/docker-compose.yml
@@ -352,6 +352,11 @@ services:
       ORG_HIGHMED_DSF_BPE_DB_USER_CAMUNDA_USERNAME: medic1_camunda_server_user
       ORG_HIGHMED_DSF_BPE_FHIR_SERVER_ORGANIZATION_IDENTIFIER_VALUE: Test_MeDIC_1
       ORG_HIGHMED_DSF_BPE_FHIR_SERVER_BASE_URL: https://medic1-docker/fhir
+      ORG_HIGHMED_DSF_BPE_MAIL_HOST: mailhog
+      ORG_HIGHMED_DSF_BPE_MAIL_PORT: 1025
+      ORG_HIGHMED_DSF_BPE_MAIL_FROMADDRESS: bpe@medic1-docker
+      ORG_HIGHMED_DSF_BPE_MAIL_TOADDRESSES: bpe@medic1-docker
+      #ORG_HIGHMED_DSF_BPE_MAIL_SENDTESTMAILONSTARTUP: 'false' # default no test mail on startup
       ORG_HIGHMED_DSF_BPE_PROCESS_EXCLUDED: highmedorg_computeFeasibility/0.6.0,highmedorg_computeDataSharing/0.6.0,highmedorg_requestUpdateResources/0.6.0,highmedorg_updateAllowList/0.6.0
       # property org.highmed.dsf.bpe.allow.list.organization should only be set for testing, do not configure property in production, potential security risk
       ORG_HIGHMED_DSF_BPE_ALLOW_LIST_ORGANIZATION: Test_TTP
@@ -416,6 +421,11 @@ services:
       ORG_HIGHMED_DSF_BPE_DB_USER_CAMUNDA_USERNAME: medic2_camunda_server_user
       ORG_HIGHMED_DSF_BPE_FHIR_SERVER_ORGANIZATION_IDENTIFIER_VALUE: Test_MeDIC_2
       ORG_HIGHMED_DSF_BPE_FHIR_SERVER_BASE_URL: https://medic2-docker/fhir
+      ORG_HIGHMED_DSF_BPE_MAIL_HOST: mailhog
+      ORG_HIGHMED_DSF_BPE_MAIL_PORT: 1025
+      ORG_HIGHMED_DSF_BPE_MAIL_FROMADDRESS: bpe@medic2-docker
+      ORG_HIGHMED_DSF_BPE_MAIL_TOADDRESSES: bpe@medic2-docker
+      #ORG_HIGHMED_DSF_BPE_MAIL_SENDTESTMAILONSTARTUP: 'false' # default no test mail on startup
       ORG_HIGHMED_DSF_BPE_PROCESS_EXCLUDED: highmedorg_computeFeasibility/0.6.0, highmedorg_computeDataSharing/0.6.0, highmedorg_requestUpdateResources/0.6.0, highmedorg_updateAllowList/0.6.0
       # property org.highmed.dsf.bpe.allow.list.organization should only be set for testing, do not configure property in production, potential security risk
       ORG_HIGHMED_DSF_BPE_ALLOW_LIST_ORGANIZATION: Test_TTP
@@ -480,6 +490,11 @@ services:
       ORG_HIGHMED_DSF_BPE_DB_USER_CAMUNDA_USERNAME: medic3_camunda_server_user
       ORG_HIGHMED_DSF_BPE_FHIR_SERVER_ORGANIZATION_IDENTIFIER_VALUE: Test_MeDIC_3
       ORG_HIGHMED_DSF_BPE_FHIR_SERVER_BASE_URL: https://medic3-docker/fhir
+      ORG_HIGHMED_DSF_BPE_MAIL_HOST: mailhog
+      ORG_HIGHMED_DSF_BPE_MAIL_PORT: 1025
+      ORG_HIGHMED_DSF_BPE_MAIL_FROMADDRESS: bpe@medic3-docker
+      ORG_HIGHMED_DSF_BPE_MAIL_TOADDRESSES: bpe@medic3-docker
+      #ORG_HIGHMED_DSF_BPE_MAIL_SENDTESTMAILONSTARTUP: 'false' # default no test mail on startup
       ORG_HIGHMED_DSF_BPE_PROCESS_EXCLUDED: >
         highmedorg_computeFeasibility/0.6.0,
         highmedorg_computeDataSharing/0.6.0,
@@ -494,6 +509,7 @@ services:
     depends_on:
       - db
       - medic3-fhir
+      - mailhog
 
   ttp-bpe:
     image: highmed/bpe
@@ -548,6 +564,12 @@ services:
       ORG_HIGHMED_DSF_BPE_DB_USER_CAMUNDA_USERNAME: ttp_camunda_server_user
       ORG_HIGHMED_DSF_BPE_FHIR_SERVER_ORGANIZATION_IDENTIFIER_VALUE: Test_TTP
       ORG_HIGHMED_DSF_BPE_FHIR_SERVER_BASE_URL: https://ttp-docker/fhir
+      ORG_HIGHMED_DSF_BPE_MAIL_HOST: mailhog
+      ORG_HIGHMED_DSF_BPE_MAIL_PORT: 1025
+      ORG_HIGHMED_DSF_BPE_MAIL_FROMADDRESS: bpe@ttp-docker
+      ORG_HIGHMED_DSF_BPE_MAIL_TOADDRESSES: bpe@ttp-docker
+      ORG_HIGHMED_DSF_BPE_MAIL_SENDTESTMAILONSTARTUP: 'true'
+      ORG_HIGHMED_DSF_BPE_MAIL_SENDMAILONERRORLOGEVENT: 'true'
       ORG_HIGHMED_DSF_BPE_PROCESS_EXCLUDED: |
         highmedorg_executeUpdateResources/0.6.0
         highmedorg_downloadAllowList/0.6.0
@@ -568,6 +590,14 @@ services:
     depends_on:
       - db
       - ttp-fhir
+      - mailhog
+
+  mailhog:
+    image: mailhog/mailhog
+    ports:
+      - 127.0.0.1:8025:8025 # web ui
+    networks:
+      internet:
 
 secrets:
   proxy_certificate_and_int_cas.pem:

--- a/dsf-fhir/dsf-fhir-server-jetty/pom.xml
+++ b/dsf-fhir/dsf-fhir-server-jetty/pom.xml
@@ -52,11 +52,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>javax.mail</groupId>
-			<artifactId>mail</artifactId>
-		</dependency>
-
-		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>jul-to-slf4j</artifactId>
 		</dependency>

--- a/dsf-fhir/dsf-fhir-server/pom.xml
+++ b/dsf-fhir/dsf-fhir-server/pom.xml
@@ -134,6 +134,11 @@
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
 		</dependency>
+		
+		<dependency>
+			<groupId>com.sun.mail</groupId>
+			<artifactId>jakarta.mail</artifactId>
+		</dependency>
 
 		<dependency>
 			<groupId>org.highmed.dsf</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -93,11 +93,16 @@
 				<artifactId>disruptor</artifactId>
 				<version>3.4.4</version>
 			</dependency>
-			<!-- smtp appender -->
+
 			<dependency>
-				<groupId>javax.mail</groupId>
-				<artifactId>mail</artifactId>
-				<version>1.4.7</version>
+				<groupId>com.sun.mail</groupId>
+				<artifactId>jakarta.mail</artifactId>
+				<version>1.6.7</version>
+			</dependency>
+			<dependency>
+				<groupId>org.bouncycastle</groupId>
+				<artifactId>bcmail-jdk15on</artifactId>
+				<version>1.70</version>
 			</dependency>
 
 			<!-- testing -->


### PR DESCRIPTION
Adds a service implementation to send e-mails from DSF processes:
- If not configured, generated e-mail will be logged
- SMTP via TLS (smtps) can be enabled
- Username/Password or client-certificate authentication to the SMTP server can be configured
- A certificate trust store for the SMTP server can be configured
- A S/MIME certificate can be configured to send signed e-mails
- The BPE will send a test mail on startup if enabled
- The BPE will send mail with Log-Message on ERROR including the last 4 INFO and WARN Messages if enabled
- SMTP via HTTP or SOCKS proxy is currently **not** implemented

closes #370